### PR TITLE
fixes #13 for version 2.5: Add traceId to assignment and telemetry sc…

### DIFF
--- a/json-schemas/apc-sensors.json
+++ b/json-schemas/apc-sensors.json
@@ -13,6 +13,12 @@
   "description": "Raw-data from door-sensor for later evaluation.",
   "additionalProperties": true,
   "properties": {
+    "traceId": {
+      "$id": "#/properties/traceId",
+      "$comment": "Added in version 2.5",
+      "type": "string",
+      "description": "A unique identifier to be able to trace this message. Also used to detect duplicate messages received."
+    },
     "doorRef": {
       "$id": "#/properties/doorRef",
       "type": "string",

--- a/json-schemas/assignment-attempt-rejection.json
+++ b/json-schemas/assignment-attempt-rejection.json
@@ -10,6 +10,18 @@
   "description": "Describes a negative result from the back-office of an attempt to sign on or off a block from MADT or another GUI",
   "additionalProperties": true,
   "properties": {
+    "eventTimestamp": {
+      "$id": "#/properties/eventTimestamp",
+      "$comment": "Added in version 2.5",
+      "type": "string",
+      "description": "ISO 8601. Reflects the current UTC time."
+    },
+    "traceId": {
+      "$id": "#/properties/traceId",
+      "$comment": "Added in version 2.5",
+      "type": "string",
+      "description": "A unique identifier to be able to trace this message. Also used to detect duplicate messages received."
+    },
     "fromDateTime": {
       "$id": "#/properties/fromDateTime",
       "type": "string",

--- a/json-schemas/assignment-attempt.json
+++ b/json-schemas/assignment-attempt.json
@@ -12,6 +12,18 @@
   "description": "Describes an attempt to sign on or off a block from MADT, another GUI or from the PTO backoffice. The result of this request will be confirmed by the PTA backoffice and the results presented either on the topic ruter/{PTO}/{vehicleID}/oi/current_ block/state or the topic ruter/{PTO}/{vehicleID}/di/assignment_attempt_rejection/block.",
   "additionalProperties": true,
   "properties": {
+    "eventTimestamp": {
+      "$id": "#/properties/eventTimestamp",
+      "$comment": "Added in version 2.5",
+      "type": "string",
+      "description": "ISO 8601. Reflects the current UTC time."
+    },
+    "traceId": {
+      "$id": "#/properties/traceId",
+      "$comment": "Added in version 2.5",
+      "type": "string",
+      "description": "A unique identifier to be able to trace this message. Also used to detect duplicate messages received."
+    },
     "fromDateTime": {
       "$id": "#/properties/fromDateTime",
       "type": "string",

--- a/json-schemas/current-block.json
+++ b/json-schemas/current-block.json
@@ -10,6 +10,18 @@
   "description": "Current block",
   "additionalProperties": true,
   "properties": {
+    "eventTimestamp": {
+      "$id": "#/properties/eventTimestamp",
+      "$comment": "Added in version 2.5",
+      "type": "string",
+      "description": "ISO 8601. Reflects the current UTC time."
+    },
+    "traceId": {
+      "$id": "#/properties/traceId",
+      "$comment": "Added in version 2.5",
+      "type": "string",
+      "description": "A unique identifier to be able to trace this message. Also used to detect duplicate messages received."
+    },
     "fromDateTime": {
       "$id": "#/properties/fromDateTime",
       "type": "string",

--- a/json-schemas/door.json
+++ b/json-schemas/door.json
@@ -10,6 +10,12 @@
   "description": "Describes if any door is open (or to be more precise – if the door lock is released). Also see topic pe/doors_individually for status on individual doors.",
   "additionalProperties": true,
   "properties": {
+    "traceId": {
+      "$id": "#/properties/traceId",
+      "$comment": "Added in version 2.5",
+      "type": "string",
+      "description": "A unique identifier to be able to trace this message. Also used to detect duplicate messages received."
+    },
     "doorOpen": {
       "$id": "#/properties/doorOpen",
       "type": "boolean",
@@ -28,7 +34,8 @@
   "examples": [
     {
       "doorOpen": true,
-      "atDateTime": "2021-11-30T23:45:52.006Z"
+      "atDateTime": "2021-11-30T23:45:52.006Z",
+      "traceId": "2d826a9a-2474-11ed-861d-0242ac120002"
     }
   ]
 }

--- a/json-schemas/doors-individually.json
+++ b/json-schemas/doors-individually.json
@@ -11,6 +11,12 @@
   "description": "This object is used to represent a door individually.",
   "additionalProperties": true,
   "properties": {
+    "traceId": {
+      "$id": "#/properties/traceId",
+      "$comment": "Added in version 2.5",
+      "type": "string",
+      "description": "A unique identifier to be able to trace this message. Also used to detect duplicate messages received."
+    },
     "doorRef": {
       "$id": "#/properties/doorRef",
       "type": "string",

--- a/json-schemas/expected-call.json
+++ b/json-schemas/expected-call.json
@@ -14,6 +14,18 @@
   "description": "The expected call object.",
   "additionalProperties": true,
   "properties": {
+    "eventTimestamp": {
+      "$id": "#/properties/eventTimestamp",
+      "$comment": "Added in version 2.5",
+      "type": "string",
+      "description": "ISO 8601. Reflects the current UTC time."
+    },
+    "traceId": {
+      "$id": "#/properties/traceId",
+      "$comment": "Added in version 2.5",
+      "type": "string",
+      "description": "A unique identifier to be able to trace this message. Also used to detect duplicate messages received."
+    },
     "updatedAtDateTime": {
       "$id": "#/properties/updatedAtDateTime",
       "type": "string",

--- a/json-schemas/odometer.json
+++ b/json-schemas/odometer.json
@@ -10,6 +10,12 @@
   "description": "Odometer data",
   "additionalProperties": true,
   "properties": {
+    "traceId": {
+      "$id": "#/properties/traceId",
+      "$comment": "Added in version 2.5",
+      "type": "string",
+      "description": "A unique identifier to be able to trace this message. Also used to detect duplicate messages received."
+    },
     "distance": {
       "$id": "#/properties/distance",
       "type": "number",
@@ -31,6 +37,7 @@
     {
       "distance": 23434556,
       "atDateTime": "2017-11-30T23:45:52.006Z",
+      "traceId": "2d826a9a-2474-11ed-861d-0242ac120002",
       "messageNumber": 12345
     }
   ]

--- a/json-schemas/telemetry.json
+++ b/json-schemas/telemetry.json
@@ -11,6 +11,12 @@
   "description": "",
   "additionalProperties": true,
   "properties": {
+    "traceId": {
+      "$id": "#/properties/traceId",
+      "$comment": "Added in version 2.5",
+      "type": "string",
+      "description": "A unique identifier to be able to trace this message. Also used to detect duplicate messages received."
+    },
     "eventTimestamp": {
       "$id": "#/properties/eventTimestamp",
       "type": "string",

--- a/json-schemas/vehicle-journey-details.json
+++ b/json-schemas/vehicle-journey-details.json
@@ -19,6 +19,18 @@
   "description": "Vehicle journey details",
   "additionalProperties": true,
   "properties": {
+    "eventTimestamp": {
+      "$id": "#/properties/eventTimestamp",
+      "$comment": "Added in version 2.5",
+      "type": "string",
+      "description": "ISO 8601. Reflects the current UTC time."
+    },
+    "traceId": {
+      "$id": "#/properties/traceId",
+      "$comment": "Added in version 2.5",
+      "type": "string",
+      "description": "A unique identifier to be able to trace this message. Also used to detect duplicate messages received."
+    },
     "operatingDayDate": {
       "$id": "#/properties/operatingDayDate",
       "type": "string",


### PR DESCRIPTION
…hemas

* apc-sensors: Add traceId. No need for eventTimestamp as atDateTime already exists
* assignment-attempt-rejection: Add traceId and eventTimestamp
* assignment-attempt: Add traceId and eventTimestamp
* current-block: Add traceId and eventTimestamp
* door: Add traceId. No need for eventTimestamp as atDateTime already exists
* doors-individually: Add traceId. No need for eventTimestamp as atDateTime already exists
* expected-call: Add traceId and eventTimestamp
* odometer: Add traceId. No need for eventTimestamp as atDateTime already exists
* telemetry: Add traceId. No need for eventTimestamp as atDateTime already exists
* vehicle-journey-details: Add traceId and eventTimestamp