### PR TITLE
ADT 3.3 changes for telemetry

### DIFF
--- a/asyncapi/asyncapi.yml
+++ b/asyncapi/asyncapi.yml
@@ -192,12 +192,25 @@ channels:
           mqtt:
             qos: 1
             retain: false
-  sensors/telemetry/{sensorId}:
+  sensors/telemetry/{telemetryId}:
     description:
       $ref: json-schemas/sensors/telemetry/telemetry.md
     parameters:
-      sensorId:
-        $ref: '#/components/parameters/sensorId'
+      telemetryId:
+        $ref: '#/components/parameters/telemetryId'
+    publish:
+      message:
+        name: Telemetry
+        schemaFormat: application/schema+json;version=draft-07
+        payload:
+          $ref: json-schemas/sensors/telemetry/telemetry.json
+        bindings:
+          mqtt:
+            qos: 0
+            retain: false
+  sensors/telemetry/0001FF25:
+    description:
+      $ref: json-schemas/sensors/telemetry/charger/charger.md
     publish:
       message:
         name: Telemetry
@@ -205,14 +218,159 @@ channels:
         payload:
           $ref: json-schemas/sensors/telemetry/telemetry.json
         examples:
-          - $ref: json-schemas/sensors/telemetry/telemetry-temperature-indoor-01.example.json
-          - $ref: json-schemas/sensors/telemetry/telemetry-soc-01.example.json
-          - $ref: json-schemas/sensors/telemetry/telemetry-windscreen-wiper-active-01.example.json
-          - $ref: json-schemas/sensors/telemetry/telemetry-charger-01.example.json
-          - $ref: json-schemas/sensors/telemetry/telemetry-accumulated-energy-consumption-01.example.json
-          - $ref: json-schemas/sensors/telemetry/telemetry-transmission-mode-01.example.json
-          - $ref: json-schemas/sensors/telemetry/telemetry-accelerometry-01.example.json
-          - $ref: json-schemas/sensors/telemetry/telemetry-temperature-outdoor-01.example.json
+          - $ref: json-schemas/sensors/telemetry/charger/charger-01.example.json
+        bindings:
+          mqtt:
+            qos: 0
+            retain: false
+  sensors/telemetry/01000002:
+    description:
+      $ref: json-schemas/sensors/telemetry/temperature-indoor/temperature-indoor.md
+    publish:
+      message:
+        name: Telemetry
+        schemaFormat: application/schema+json;version=draft-07
+        payload:
+          $ref: json-schemas/sensors/telemetry/telemetry.json
+        examples:
+          - $ref: json-schemas/sensors/telemetry/temperature-indoor/temperature-indoor-01.example.json
+        bindings:
+          mqtt:
+            qos: 0
+            retain: false
+  sensors/telemetry/01000005:
+    description:
+      $ref: json-schemas/sensors/telemetry/state-of-charge/state-of-charge.md
+    publish:
+      message:
+        name: Telemetry
+        schemaFormat: application/schema+json;version=draft-07
+        payload:
+          $ref: json-schemas/sensors/telemetry/telemetry.json
+        examples:
+          - $ref: json-schemas/sensors/telemetry/state-of-charge/state-of-charge-01.example.json
+        bindings:
+          mqtt:
+            qos: 0
+            retain: false
+  sensors/telemetry/01000006:
+    description:
+      $ref: json-schemas/sensors/telemetry/transmission-mode/transmission-mode.md
+    publish:
+      message:
+        name: Telemetry
+        schemaFormat: application/schema+json;version=draft-07
+        payload:
+          $ref: json-schemas/sensors/telemetry/telemetry.json
+        examples:
+          - $ref: json-schemas/sensors/telemetry/transmission-mode/transmission-mode-01.example.json
+        bindings:
+          mqtt:
+            qos: 0
+            retain: false
+  sensors/telemetry/01000007:
+    description:
+      $ref: json-schemas/sensors/telemetry/windscreen-wiper-active/windscreen-wiper-active.md
+    publish:
+      message:
+        name: Telemetry
+        schemaFormat: application/schema+json;version=draft-07
+        payload:
+          $ref: json-schemas/sensors/telemetry/telemetry.json
+        examples:
+          - $ref: json-schemas/sensors/telemetry/windscreen-wiper-active/windscreen-wiper-active-01.example.json
+        bindings:
+          mqtt:
+            qos: 0
+            retain: false
+  sensors/telemetry/01000008:
+    description:
+      $ref: json-schemas/sensors/telemetry/accelerometry/accelerometry.md
+    publish:
+      message:
+        name: Telemetry
+        schemaFormat: application/schema+json;version=draft-07
+        payload:
+          $ref: json-schemas/sensors/telemetry/telemetry.json
+        examples:
+          - $ref: json-schemas/sensors/telemetry/accelerometry/accelerometry-01.example.json
+        bindings:
+          mqtt:
+            qos: 0
+            retain: false
+  sensors/telemetry/01000009:
+    description:
+      $ref: json-schemas/sensors/telemetry/temperature-outdoor/temperature-outdoor.md
+    publish:
+      message:
+        name: Telemetry
+        schemaFormat: application/schema+json;version=draft-07
+        payload:
+          $ref: json-schemas/sensors/telemetry/telemetry.json
+        examples:
+          - $ref: json-schemas/sensors/telemetry/temperature-outdoor/temperature-outdoor-01.example.json
+        bindings:
+          mqtt:
+            qos: 0
+            retain: false
+  sensors/telemetry/0100000A:
+    description:
+      $ref: json-schemas/sensors/telemetry/accumulated-energy-consumption/accumulated-energy-consumption.md
+    publish:
+      message:
+        name: Telemetry
+        schemaFormat: application/schema+json;version=draft-07
+        payload:
+          $ref: json-schemas/sensors/telemetry/telemetry.json
+        examples:
+          - $ref: json-schemas/sensors/telemetry/accumulated-energy-consumption/accumulated-energy-consumption-01.example.json
+        bindings:
+          mqtt:
+            qos: 0
+            retain: false
+  sensors/charging:
+    description:
+      $ref: json-schemas/sensors/charging/charging.md
+    publish:
+      message:
+        name: Charging
+        schemaFormat: application/schema+json;version=draft-07
+        payload:
+          $ref: json-schemas/sensors/charging/charging.json
+        examples:
+          - $ref: json-schemas/sensors/charging/charging-01.example.json
+          - $ref: json-schemas/sensors/charging/charging-02.example.json
+          - $ref: json-schemas/sensors/charging/charging-03.example.json
+        bindings:
+          mqtt:
+            qos: 0
+            retain: false
+  sensors/temperature/water:
+    description:
+      $ref: json-schemas/sensors/temperature-water/temperature-water.md
+    publish:
+      message:
+        name: TemperatureWater
+        schemaFormat: application/schema+json;version=draft-07
+        payload:
+          $ref: json-schemas/sensors/temperature-water/temperature-water.json
+        examples:
+          - $ref: json-schemas/sensors/temperature-water/temperature-water-01.example.json
+        bindings:
+          mqtt:
+            qos: 0
+            retain: false
+  sensors/wind:
+    description:
+      $ref: json-schemas/sensors/wind/wind.md
+    publish:
+      message:
+        name: Wind
+        schemaFormat: application/schema+json;version=draft-07
+        payload:
+          $ref: json-schemas/sensors/wind/wind.json
+        examples:
+          - $ref: json-schemas/sensors/wind/wind-01.example.json
         bindings:
           mqtt:
             qos: 0
@@ -599,7 +757,11 @@ components:
       schema:
         type: string
     sensorId:
-      description: The sensor / telemetry Id.
+      description: The sensor ID
+      schema:
+        type: string
+    telemetryId:
+      description: An unique ID of the telemetry type.
       schema:
         type: string
     deviceRef:

--- a/asyncapi/asyncapi.yml
+++ b/asyncapi/asyncapi.yml
@@ -757,7 +757,7 @@ components:
       schema:
         type: string
     sensorId:
-      description: The sensor ID
+      description: Identification of the physical sensor, e.g. serial number
       schema:
         type: string
     telemetryId:

--- a/asyncapi/json-schemas/sensors/charging/charging-01.example.json
+++ b/asyncapi/json-schemas/sensors/charging/charging-01.example.json
@@ -1,0 +1,12 @@
+{
+  "name": "Charging",
+  "payload": {
+    "eventTimestamp": "2023-05-10T14:30:00Z",
+    "traceId": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+    "sensorId": "XB7F-9T2M-L4FC-3R8Q",
+    "messageNumber": 42,
+    "isConnected": true,
+    "isCharging": true,
+    "chargingEffect": 100.0
+  }
+}

--- a/asyncapi/json-schemas/sensors/charging/charging-01.example.json
+++ b/asyncapi/json-schemas/sensors/charging/charging-01.example.json
@@ -7,6 +7,6 @@
     "messageNumber": 42,
     "isConnected": true,
     "isCharging": true,
-    "chargingEffect": 100.0
+    "chargingEffect": 155.1
   }
 }

--- a/asyncapi/json-schemas/sensors/charging/charging-02.example.json
+++ b/asyncapi/json-schemas/sensors/charging/charging-02.example.json
@@ -1,0 +1,12 @@
+{
+  "name": "Charging",
+  "payload": {
+    "eventTimestamp": "2023-05-10T14:30:00Z",
+    "traceId": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+    "sensorId": "XB7F-9T2M-L4FC-3R8Q",
+    "messageNumber": 42,
+    "isConnected": true,
+    "isCharging": false,
+    "chargingEffect": 0.0
+  }
+}

--- a/asyncapi/json-schemas/sensors/charging/charging-03.example.json
+++ b/asyncapi/json-schemas/sensors/charging/charging-03.example.json
@@ -1,0 +1,12 @@
+{
+  "name": "Charging",
+  "payload": {
+    "eventTimestamp": "2023-05-10T14:30:00Z",
+    "traceId": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+    "sensorId": "XB7F-9T2M-L4FC-3R8Q",
+    "messageNumber": 42,
+    "isConnected": false,
+    "isCharging": false,
+    "chargingEffect": 0
+  }
+}

--- a/asyncapi/json-schemas/sensors/charging/charging-03.example.json
+++ b/asyncapi/json-schemas/sensors/charging/charging-03.example.json
@@ -7,6 +7,6 @@
     "messageNumber": 42,
     "isConnected": false,
     "isCharging": false,
-    "chargingEffect": 0
+    "chargingEffect": 0.0
   }
 }

--- a/asyncapi/json-schemas/sensors/charging/charging.json
+++ b/asyncapi/json-schemas/sensors/charging/charging.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://example.com/schemas/vehicle-charging.json",
+  "type": "object",
+  "title": "Vehicle Charging",
+  "description": "Schema for vehicle charging data",
+  "required": [
+    "eventTimestamp",
+    "traceId",
+    "sensorId",
+    "messageNumber",
+    "isConnected",
+    "isCharging",
+    "chargingEffect"
+  ],
+  "properties": {
+    "eventTimestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of when the measurement was taken"
+    },
+    "traceId": {
+      "type": "string",
+      "description": "Unique identifier for tracing this message"
+    },
+    "sensorId": {
+      "type": "string",
+      "description": "Unique identifier for the sensor. Typically the serial number (S/N) from the sensor."
+    },
+    "messageNumber": {
+      "type": "integer",
+      "description": "Sequence number, increased by one for each new message."
+    },
+    "isConnected": {
+      "type": "boolean",
+      "description": "Indicates whether the vehicle is connected to a charging point"
+    },
+    "isCharging": {
+      "type": "boolean",
+      "description": "Indicates whether the vehicle is currently charging"
+    },
+    "chargingEffect": {
+      "type": "number",
+      "description": "The current charging effect in kilowatts (kW)"
+    }
+  },
+  "additionalProperties": true
+}

--- a/asyncapi/json-schemas/sensors/charging/charging.md
+++ b/asyncapi/json-schemas/sensors/charging/charging.md
@@ -13,7 +13,7 @@ vehicle is connected to a charging point, if it's actively charging, and the cur
 
 #### Data specification
 
-Frequency:
+Message frequency:
 - Messages should be sent on change, i.e., when there's a change in connection status, charging status, or a change in
 charging effect more or equal to 10kW.
 

--- a/asyncapi/json-schemas/sensors/charging/charging.md
+++ b/asyncapi/json-schemas/sensors/charging/charging.md
@@ -1,0 +1,30 @@
+### Charging Message
+
+| Field         | Value                                                                                                     |
+|:--------------|:----------------------------------------------------------------------------------------------------------|
+| Central Topic | ruter/{operatorId}/{vehicleId}/adt/v3/sensors/charging                                                    |
+| Schema        | [ charging.json ](json-schemas/sensors/charging/charging.json)                                            |
+| Producer      | PTO                                                                                                       |
+| Consumer      | Ruter BO                                                                                                  |
+| Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version. |
+
+Describes the charging status and details of an electric vehicle. The message includes information about whether the
+vehicle is connected to a charging point, if it's actively charging, and the current charging effect in kilowatts (kW).
+
+#### Data specification
+
+Frequency:
+- Messages should be sent on change, i.e., when there's a change in connection status, charging status, or a change in
+charging effect more or equal to 10kW.
+
+Properties:
+- isConnected:
+  - Boolean value indicating if the vehicle is connected to a charging point
+
+- isCharging:
+  - Boolean value indicating if the vehicle is actively charging
+
+- chargingEffect:
+  - Unit: kilowatts (kW)
+  - Resolution: <0.1kW
+  - Range: >=0.0kW

--- a/asyncapi/json-schemas/sensors/charging/charging.md
+++ b/asyncapi/json-schemas/sensors/charging/charging.md
@@ -25,6 +25,6 @@ Properties:
   - Boolean value indicating if the vehicle is actively charging
 
 - chargingEffect:
-  - Unit: kilowatts (kW)
-  - Resolution: <0.1kW
+  - Unit: Kilowatts (kW)
+  - Resolution: Minimum one decimal (<=0.1kW)
   - Range: >=0.0kW

--- a/asyncapi/json-schemas/sensors/charging/charging.meta.json
+++ b/asyncapi/json-schemas/sensors/charging/charging.meta.json
@@ -1,0 +1,9 @@
+{
+  "mode": "publish",
+  "mqtt": {
+    "qos": 0,
+    "retain": false,
+    "topic": "ruter/{operatorId}/{vehicleId}/adt/v3/sensors/charging",
+    "params": []
+  }
+}

--- a/asyncapi/json-schemas/sensors/telemetry/accelerometry/accelerometry-01.example.json
+++ b/asyncapi/json-schemas/sensors/telemetry/accelerometry/accelerometry-01.example.json
@@ -1,63 +1,47 @@
 {
   "name": "Accelerometry",
   "payload": {
+    "name": "Accelerometry",
     "eventTimestamp": "2022-05-09T13:27:59.624Z",
     "traceId": "3841a268-0c03-4588-b476-211be0f26a0d",
     "messageNumber": 1,
     "id": "01000008",
+    "sensorId": "XB7F-9T2M-L4FC-3R8Q",
     "payloads": [
       {
         "subid": "xmin",
-        "name": "Min x value last interval",
-        "unit": "g",
         "value": 0.1
       },
       {
         "subid": "xmax",
-        "name": "Max x value last interval",
-        "unit": "g",
         "value": 0.2
       },
       {
         "subid": "xavg",
-        "name": "Average x value last interval",
-        "unit": "g",
         "value": 0.15
       },
       {
         "subid": "ymin",
-        "name": "Min y value last interval",
-        "unit": "g",
         "value": -0.1
       },
       {
         "subid": "ymax",
-        "name": "Max y value last interval",
-        "unit": "g",
         "value": 0.2
       },
       {
         "subid": "yavg",
-        "name": "Average y value last interval",
-        "unit": "g",
         "value": 0.1
       },
       {
         "subid": "zmin",
-        "name": "Min z value last interval",
-        "unit": "g",
         "value": 0.01
       },
       {
         "subid": "zmax",
-        "name": "Max z value last interval",
-        "unit": "g",
         "value": 0.03
       },
       {
         "subid": "zavg",
-        "name": "Average z value last interval",
-        "unit": "g",
         "value": 0.02
       }
     ]

--- a/asyncapi/json-schemas/sensors/telemetry/accelerometry/accelerometry.md
+++ b/asyncapi/json-schemas/sensors/telemetry/accelerometry/accelerometry.md
@@ -1,0 +1,35 @@
+### Accelerometry Message
+
+| Field         | Value                                                                                                     |
+|---------------|-----------------------------------------------------------------------------------------------------------|
+| Central Topic | ruter/{operatorId}/{vehicleId}/adt/v3/sensors/telemetry/01000008                                          |
+| Schema        | [ telemetry.json ](json-schemas/sensors/telemetry/telemetry.json)                                         |
+| Producer      | PTO                                                                                                       |
+| Consumer      | Ruter BO                                                                                                  |
+| Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version. | 
+
+Describes the vehicle's acceleration in three dimensions.
+
+#### Data Specifications
+
+- **Frequency:** 6 times per minute (6/min)
+- **Bandwidth:** ≥ 100 Hz
+- **Unit:** g (gravity)
+- **Resolution:** ≤ 0.01 g
+
+#### Payload details
+
+- **Name:** Accelerometry
+- **ID:** 01000008
+
+| Sub Id | Value Type | Description                 |
+|:------:|:----------:|-----------------------------|
+|  xmin  |   float    | Minimum X-axis acceleration |
+|  xmax  |   float    | Maximum X-axis acceleration |
+|  xavg  |   float    | Average X-axis acceleration |
+|  ymin  |   float    | Minimum Y-axis acceleration |
+|  ymax  |   float    | Maximum Y-axis acceleration |
+|  yavg  |   float    | Average Y-axis acceleration |
+|  zmin  |   float    | Minimum Z-axis acceleration |
+|  zmax  |   float    | Maximum Z-axis acceleration |
+|  zavg  |   float    | Average Z-axis acceleration |

--- a/asyncapi/json-schemas/sensors/telemetry/accelerometry/accelerometry.md
+++ b/asyncapi/json-schemas/sensors/telemetry/accelerometry/accelerometry.md
@@ -12,7 +12,7 @@ Describes the vehicle's acceleration in three dimensions.
 
 #### Data Specifications
 
-- **Frequency:** 6 times per minute (6/min)
+- **Message frequency:** 6 times per minute (6/min)
 - **Bandwidth:** ≥ 100 Hz
 - **Unit:** g (gravity)
 - **Resolution:** ≤ 0.01 g

--- a/asyncapi/json-schemas/sensors/telemetry/accelerometry/accelerometry.meta.json
+++ b/asyncapi/json-schemas/sensors/telemetry/accelerometry/accelerometry.meta.json
@@ -1,0 +1,8 @@
+{
+  "mode": "publish",
+  "mqtt": {
+    "qos": 0,
+    "retain": false,
+    "topic": "ruter/{operatorId}/{vehicleId}/adt/v3/sensors/telemetry/01000008"
+  }
+}

--- a/asyncapi/json-schemas/sensors/telemetry/accumulated-energy-consumption/accumulated-energy-consumption-01.example.json
+++ b/asyncapi/json-schemas/sensors/telemetry/accumulated-energy-consumption/accumulated-energy-consumption-01.example.json
@@ -1,0 +1,16 @@
+{
+  "name": "Accumulated energy consumption",
+  "payload": {
+    "eventTimestamp": "2022-05-09T13:27:59.624Z",
+    "traceId": "3841a268-0c03-4588-b476-211be0f26a0d",
+    "messageNumber": 1,
+    "id": "0100000A",
+    "payloads": [
+      {
+        "name": "Accumulated energy consumption",
+        "sensorId": "XB7F-9T2M-L4FC-3R8Q",
+        "value": 0.972
+      }
+    ]
+  }
+}

--- a/asyncapi/json-schemas/sensors/telemetry/accumulated-energy-consumption/accumulated-energy-consumption.md
+++ b/asyncapi/json-schemas/sensors/telemetry/accumulated-energy-consumption/accumulated-energy-consumption.md
@@ -14,7 +14,7 @@ Describes total energy consumption by the vehicle.
 
 Energy consumed including HVAC
 
-- **Frequency:** Once per minute (1/min)
+- **Message frequency:** Once per minute (1/min)
 - **Unit:** kWh
 
 #### Payload details

--- a/asyncapi/json-schemas/sensors/telemetry/accumulated-energy-consumption/accumulated-energy-consumption.md
+++ b/asyncapi/json-schemas/sensors/telemetry/accumulated-energy-consumption/accumulated-energy-consumption.md
@@ -1,0 +1,27 @@
+### Accumulated Energy Consumption Message
+
+| Field         | Value                                                                                                     |
+|---------------|-----------------------------------------------------------------------------------------------------------|
+| Central Topic | ruter/{operatorId}/{vehicleId}/adt/v3/sensors/telemetry/0100000A                                          |
+| Schema        | [ telemetry.json ](json-schemas/sensors/telemetry/telemetry.json)                                         |
+| Producer      | PTO                                                                                                       |
+| Consumer      | Ruter BO                                                                                                  |
+| Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version. |
+
+Describes total energy consumption by the vehicle.
+
+#### Data specification
+
+Energy consumed including HVAC
+
+- **Frequency:** Once per minute (1/min)
+- **Unit:** kWh
+
+#### Payload details
+
+- **Name:** Accumulated energy consumption
+- **ID:** 0100000A
+
+| Value Type | Description                    |
+|------------|--------------------------------|
+| float      | Accumulated energy consumption |

--- a/asyncapi/json-schemas/sensors/telemetry/accumulated-energy-consumption/accumulated-energy-consumption.meta.json
+++ b/asyncapi/json-schemas/sensors/telemetry/accumulated-energy-consumption/accumulated-energy-consumption.meta.json
@@ -1,0 +1,8 @@
+{
+  "mode": "publish",
+  "mqtt": {
+    "qos": 0,
+    "retain": false,
+    "topic": "ruter/{operatorId}/{vehicleId}/adt/v3/sensors/telemetry/0100000A"
+  }
+}

--- a/asyncapi/json-schemas/sensors/telemetry/charger/charger-01.example.json
+++ b/asyncapi/json-schemas/sensors/telemetry/charger/charger-01.example.json
@@ -1,8 +1,10 @@
 {
   "name": "Charger",
   "payload": {
+    "name": "Charger",
     "eventTimestamp": "2022-05-09T13:27:59.624Z",
     "traceId": "3841a268-0c03-4588-b476-211be0f26a0d",
+    "sensorId": "XB7F-9T2M-L4FC-3R8Q",
     "messageNumber": 1,
     "id": "0001FF25",
     "payloads": [

--- a/asyncapi/json-schemas/sensors/telemetry/charger/charger.md
+++ b/asyncapi/json-schemas/sensors/telemetry/charger/charger.md
@@ -1,0 +1,28 @@
+### Charger Message (deprecated)
+
+| Field         | Value                                                                                                     |
+|---------------|-----------------------------------------------------------------------------------------------------------|
+| Central Topic | ruter/{operatorId}/{vehicleId}/adt/v3/sensors/telemetry/0001FF25                                          |
+| Schema        | [ telemetry.json ](json-schemas/sensors/telemetry/telemetry.json)                                         |
+| Producer      | PTO                                                                                                       |
+| Consumer      | Ruter BO                                                                                                  |
+| Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version. |
+
+> This has been deprecated and will be removed in the next major version. See´sensors/charging´ for information about new topic.
+
+Describes the charging status and details of an electric vehicle.
+
+#### Data specification
+
+- **Frequency:** On change
+
+#### Payload details
+
+- **Name:** Charger
+- **ID:** 0001FF25
+
+| Sub ID | Name                   | Value Type | Description                                   |
+|--------|------------------------|------------|-----------------------------------------------|
+| 10003  | Wall charger connected | boolean    | Indicates if connected to a wall charger      |
+| 10004  | Fast charger connected | boolean    | Indicates if connected to a fast charger      |
+| 10005  | Charging active        | boolean    | Indicates if the vehicle is actively charging |

--- a/asyncapi/json-schemas/sensors/telemetry/charger/charger.md
+++ b/asyncapi/json-schemas/sensors/telemetry/charger/charger.md
@@ -14,7 +14,7 @@ Describes the charging status and details of an electric vehicle.
 
 #### Data specification
 
-- **Frequency:** On change
+- **Message frequency:** On change
 
 #### Payload details
 

--- a/asyncapi/json-schemas/sensors/telemetry/charger/charger.meta.json
+++ b/asyncapi/json-schemas/sensors/telemetry/charger/charger.meta.json
@@ -1,0 +1,8 @@
+{
+  "mode": "publish",
+  "mqtt": {
+    "qos": 0,
+    "retain": false,
+    "topic": "ruter/{operatorId}/{vehicleId}/adt/v3/sensors/telemetry/0001FF25"
+  }
+}

--- a/asyncapi/json-schemas/sensors/telemetry/state-of-charge/state-of-charge-01.example.json
+++ b/asyncapi/json-schemas/sensors/telemetry/state-of-charge/state-of-charge-01.example.json
@@ -1,14 +1,15 @@
 {
-  "name": "Windscreen wiper active",
+  "name": "State of charge",
   "payload": {
     "eventTimestamp": "2022-05-09T13:27:59.624Z",
     "traceId": "3841a268-0c03-4588-b476-211be0f26a0d",
     "messageNumber": 1,
-    "id": "01000007",
+    "id": "01000005",
     "payloads": [
       {
-        "name": "Windscreen wiper active",
-        "value": true
+        "name": "State of charge",
+        "sensorId": "XB7F-9T2M-L4FC-3R8Q",
+        "value": 20.3
       }
     ]
   }

--- a/asyncapi/json-schemas/sensors/telemetry/state-of-charge/state-of-charge-02.example.json
+++ b/asyncapi/json-schemas/sensors/telemetry/state-of-charge/state-of-charge-02.example.json
@@ -7,9 +7,10 @@
     "id": "01000005",
     "payloads": [
       {
+        "subId": "1",
         "name": "State of charge",
-        "sensorId": "XB7F-9T2M-L4FC-3R8Q",
-        "value": 20.3
+        "sensorId": "XB7F-9T2M-L4FC-JK32",
+        "value": 30
       }
     ]
   }

--- a/asyncapi/json-schemas/sensors/telemetry/state-of-charge/state-of-charge-02.example.json
+++ b/asyncapi/json-schemas/sensors/telemetry/state-of-charge/state-of-charge-02.example.json
@@ -1,0 +1,16 @@
+{
+  "name": "State of charge",
+  "payload": {
+    "eventTimestamp": "2022-05-09T13:27:59.624Z",
+    "traceId": "3841a268-0c03-4588-b476-211be0f26a0d",
+    "messageNumber": 1,
+    "id": "01000005",
+    "payloads": [
+      {
+        "name": "State of charge",
+        "sensorId": "XB7F-9T2M-L4FC-3R8Q",
+        "value": 20.3
+      }
+    ]
+  }
+}

--- a/asyncapi/json-schemas/sensors/telemetry/state-of-charge/state-of-charge-03.example.json
+++ b/asyncapi/json-schemas/sensors/telemetry/state-of-charge/state-of-charge-03.example.json
@@ -7,10 +7,16 @@
     "id": "01000005",
     "payloads": [
       {
-        "subid":
+        "subId": "1",
         "name": "State of charge",
         "sensorId": "XB7F-9T2M-L4FC-3R8Q",
         "value": 20.3
+      },
+      {
+        "subId": "2",
+        "name": "State of charge",
+        "sensorId": "XB7F-9T2M-L4FC-JK32",
+        "value": 30
       }
     ]
   }

--- a/asyncapi/json-schemas/sensors/telemetry/state-of-charge/state-of-charge-03.example.json
+++ b/asyncapi/json-schemas/sensors/telemetry/state-of-charge/state-of-charge-03.example.json
@@ -1,14 +1,16 @@
 {
-  "name": "Transmission mode",
+  "name": "State of charge",
   "payload": {
     "eventTimestamp": "2022-05-09T13:27:59.624Z",
     "traceId": "3841a268-0c03-4588-b476-211be0f26a0d",
     "messageNumber": 1,
-    "id": "01000006",
+    "id": "01000005",
     "payloads": [
       {
-        "name": "Transmission mode",
-        "value": "electric"
+        "subid":
+        "name": "State of charge",
+        "sensorId": "XB7F-9T2M-L4FC-3R8Q",
+        "value": 20.3
       }
     ]
   }

--- a/asyncapi/json-schemas/sensors/telemetry/state-of-charge/state-of-charge.md
+++ b/asyncapi/json-schemas/sensors/telemetry/state-of-charge/state-of-charge.md
@@ -12,7 +12,7 @@ Describes the current charge level of the vehicle's battery.
 
 #### Data specification
 
-- **Frequency:** Once per minute (1/min)
+- **Message frequency:** Once per minute (1/min)
 - **Unit:** Percentage (%)
 - **Resolution:** <= 1%
 - **Range:** 0% - 100%

--- a/asyncapi/json-schemas/sensors/telemetry/state-of-charge/state-of-charge.md
+++ b/asyncapi/json-schemas/sensors/telemetry/state-of-charge/state-of-charge.md
@@ -1,0 +1,32 @@
+### State of Charge Message
+
+| Field         | Value                                                                                                     |
+|---------------|-----------------------------------------------------------------------------------------------------------|
+| Central Topic | ruter/{operatorId}/{vehicleId}/adt/v3/sensors/telemetry/01000005                                          |
+| Schema        | [ telemetry.json ](json-schemas/sensors/telemetry/telemetry.json)                                         |
+| Producer      | PTO                                                                                                       |
+| Consumer      | Ruter BO                                                                                                  |
+| Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version. | 
+
+Describes the current charge level of the vehicle's battery.
+
+#### Data specification
+
+- **Frequency:** Once per minute (1/min)
+- **Unit:** Percentage (%)
+- **Resolution:** <= 1%
+- **Range:** 0% - 100%
+
+#### Payload details
+
+- **Name:** State of charge
+- **ID:** 01000005
+
+If vehicle has more than one battery use the sub id to identify them:
+
+| Sub ID | Name            | Value Type | Description                           |
+|--------|-----------------|------------|---------------------------------------|
+| N/A    | State of charge | float      | Only one battery in the given vehicle |
+| 1      | State of charge | float      | Battery 1                             |
+| 2      | State of charge | float      | Battery 2                             |
+| (n)    | State of charge | float      | Battery (n)                           |

--- a/asyncapi/json-schemas/sensors/telemetry/state-of-charge/state-of-charge.meta.json
+++ b/asyncapi/json-schemas/sensors/telemetry/state-of-charge/state-of-charge.meta.json
@@ -1,0 +1,8 @@
+{
+  "mode": "publish",
+  "mqtt": {
+    "qos": 0,
+    "retain": false,
+    "topic": "ruter/{operatorId}/{vehicleId}/adt/v3/sensors/telemetry/01000005"
+  }
+}

--- a/asyncapi/json-schemas/sensors/telemetry/telemetry.json
+++ b/asyncapi/json-schemas/sensors/telemetry/telemetry.json
@@ -1,64 +1,78 @@
 {
-  "$id": "https://schemas.ruter.no/adt/ota/api/v3.0/sensors/telemetry/telemetry.json",
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Telemetry",
-  "type": "object",
-  "required": [
-    "eventTimestamp",
-    "traceId",
-    "id",
-    "payloads"
-  ],
-  "description": "",
-  "additionalProperties": true,
-  "properties": {
-    "traceId": {
-      "$id": "#/properties/traceId",
-      "$comment": "Added in version 2.5",
-      "type": "string",
-      "description": "A unique identifier to be able to trace this message. Also used to detect duplicate messages received."
-    },
-    "eventTimestamp": {
-      "$id": "#/properties/eventTimestamp",
-      "type": "string",
-      "description": "As specified in the [ADT documentation.](https://adt.transhub.io)."
-    },
-    "messageNumber": {
-      "$id": "#/properties/messageNumber",
-      "$comment": "Added in version 2.1",
-      "type": "number",
-      "description": "Sequence number, increased by one for each new message. Used to validate consistency in the data stream."
-    },
-    "id": {
-      "$id": "#/properties/id",
-      "type": "string",
-      "description": "Eight digit hex as defined above."
-    },
-    "payloads": {
-      "$id": "#/properties/payloads",
-      "type": "array",
-      "description": "",
-      "items": {
-        "type": "object",
-        "required": ["value"],
-        "properties": {
-          "subid": {
+    "$id": "https://schemas.ruter.no/adt/ota/api/v3.3/sensors/telemetry/telemetry.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Telemetry",
+    "type": "object",
+    "required": [
+        "eventTimestamp",
+        "traceId",
+        "id",
+        "payloads"
+    ],
+    "description": "Schema for telemetry data, supporting both single-sensor and multi-sensor payloads.",
+    "additionalProperties": true,
+    "properties": {
+        "traceId": {
+            "$id": "#/properties/traceId",
             "type": "string",
-            "description": "Subid is used to identify the payload when there is more than one possible type of payload."
-          },
-          "name": {
+            "description": "A unique identifier to be able to trace this message. Also used to detect duplicate messages received. Added in version 2.5."
+        },
+        "eventTimestamp": {
+            "$id": "#/properties/eventTimestamp",
             "type": "string",
-            "description": "Descriptive name of the payload"
-          },
-          "unit": {
+            "description": "As specified in the [ADT documentation.](https://adt.transhub.io)."
+        },
+        "messageNumber": {
+            "$id": "#/properties/messageNumber",
+            "type": "number",
+            "description": "Sequence number, increased by one for each new message. Used to validate consistency in the data stream. Added in version 2.1."
+        },
+        "id": {
+            "$id": "#/properties/id",
             "type": "string",
-            "description": "Unit used by the sensor. Only used for number values"
-          },
-          "value": {
-            "description": "The value is expected to be a number, boolean, or string."
-          }
+            "description": "Eight digit hex identifying the telemetry."
+        },
+        "name": {
+            "$id": "#/properties/name",
+            "type": "string",
+            "description": "Optional name for the overall telemetry system or the main sensor. Added in version 3.3."
+        },
+        "sensorId": {
+            "$id": "#/properties/physicalSensorId",
+            "type": "string",
+            "description": "Unique identifier for the sensor. Typically the serial number (S/N) from the sensor. Added in version 3.3."
+        },
+        "payloads": {
+            "$id": "#/properties/payloads",
+            "type": "array",
+            "description": "Array of payload items, which can represent multiple values from a single sensor or values from different sensors.",
+            "items": {
+                "type": "object",
+                "required": [
+                    "value"
+                ],
+                "properties": {
+                    "subid": {
+                        "type": "string",
+                        "description": "Subid is used to identify the specific measurement type within a payload."
+                    },
+                    "sensorId": {
+                        "type": "string",
+                        "description": "Unique identifier for the sensor. Typically the serial number (S/N) from the sensor. Added in version 3.3."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Descriptive name of the payload item."
+                    },
+                    "unit": {
+                        "type": "string",
+                        "description": "Unit used by the sensor. Only used for number values."
+                    },
+                    "value": {
+                        "description": "The value is expected to be a number, boolean, or string."
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }

--- a/asyncapi/json-schemas/sensors/telemetry/telemetry.json
+++ b/asyncapi/json-schemas/sensors/telemetry/telemetry.json
@@ -38,7 +38,7 @@
             "description": "Optional name for the overall telemetry system or the main sensor. Added in version 3.3."
         },
         "sensorId": {
-            "$id": "#/properties/physicalSensorId",
+            "$id": "#/properties/sensorId",
             "type": "string",
             "description": "Unique identifier for the sensor. Typically the serial number (S/N) from the sensor. Added in version 3.3."
         },

--- a/asyncapi/json-schemas/sensors/telemetry/telemetry.md
+++ b/asyncapi/json-schemas/sensors/telemetry/telemetry.md
@@ -1,55 +1,55 @@
 ### Telemetry Message
+
 | Field         | Value                                                                                                     |
 |---------------|-----------------------------------------------------------------------------------------------------------|
-| Central Topic | ruter/{operatorId}/{vehicleId}/adt/v3/sensors/telemetry/{sensorId}                                        |
+| Central Topic | ruter/{operatorId}/{vehicleId}/adt/v3/sensors/telemetry/{telemetryId}                                     |
 | Schema        | [ telemetry.json ](json-schemas/sensors/telemetry/telemetry.json)                                         |
 | Producer      | PTO                                                                                                       |
 | Consumer      | Ruter BO                                                                                                  |
 | Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version. | 
 
+For telemetry not listed in the Available ADT Telemetry section below, refer to the FMS (Fleet Management System)
+standard documentation. However, before using the FMS standard directly:
 
-Several different kinds of sensor/telemetry data are available varying by vehicle type For traditional busses, FMS is the standard that defines what data about the vehicle is published on the FMS bus and further on by ITxPT FMStoIP [service.In](http://service.In "http://service.In") addition, vessels, trams and different bus types have proprietary data not captured by FMS.
+- Check if the data point already exists in the MQTT API or ADT telemetry listed below.
+- If not listed, contact Ruter to discuss potential implementation before defaulting to the FMS standard.
 
-According to the data centric approach from ITxPT, several of these data types (door, location, stop button etc) have been assigned separate topics as being described in this document. However, data types required by Ruter that haven’t yet been described in the MQTT structure from ITxPT, will still be handled by the general Telemetry topic that was introduced by Ruter in 2019.
+Several different kinds of sensor/telemetry data are available varying by vehicle type For traditional busses, FMS is
+the standard that defines what data about the vehicle is published on the FMS bus and further on by ITxPT
+FMStoIP [service.In](http://service.In "http://service.In") addition, vessels, trams and different bus types have
+proprietary data not captured by FMS.
 
-All such data are defined by unique, 32 bit, identifiers. Data caught from the FMS bus retain their PGN numbers as the last 16 bits of the ID. Data not coming from the FMS bus follow a separate addressing scheme, with addresses allocated by Ruter on request. Please note that PTOs are free to decide if they want to use FMS or a non-FMS data source to provide the data.
+According to the data centric approach from ITxPT, several of these data types (door, location, stop button etc) have
+been assigned separate topics as being described in this document. However, data types required by Ruter that haven’t
+yet been described in the MQTT structure from ITxPT, will still be handled by the general Telemetry topic that was
+introduced by Ruter in 2019.
 
-To utilize FMS data in Ruter’s architecture, Operators can either set up an FMS2IP service or use any other means to subscribe to the FMS bus data. Note that there must be one separate MQTT message per FMS PGN.
+All such data are defined by unique, 32 bit, identifiers. Data caught from the FMS bus retain their PGN numbers as the
+last 16 bits of the ID. Data not coming from the FMS bus follow a separate addressing scheme, with addresses allocated
+by Ruter on request. Please note that PTOs are free to decide if they want to use FMS or a non-FMS data source to
+provide the data.
+
+To utilize FMS data in Ruter’s architecture, Operators can either set up an FMS2IP service or use any other means to
+subscribe to the FMS bus data. Note that there must be one separate MQTT message per FMS PGN.
 
 The identifiers are constructed this way:
 
-
-|Bytes | Description |
-| --- | --- |
-**1** | Source identifier (0x00 FMS, 0x01 Non-FMS)
-**2-4** | Source-specific id, e.g. FMS PGNs
+|  Bytes  |  Description                               |
+|:-------:|:-------------------------------------------|
+|  **1**  | Source identifier (0x00 FMS, 0x01 Non-FMS) | 
+| **2-4** | Source-specific id, e.g. FMS PGNs          |          
 
 ## Available Non-FMS standard data identifiers
-Optional unless stated explicitly in the main ADT document.
 
-ID | Subid | Name | Value | Recommended refresh interval | Remarks
---- | --- | --- | --- | --- | ---
-**0001FF25** | | Charger | | onChange | 
-| | 10003 | Wall charger connected | boolean | | 
-| | 10004 | Fast charger connected | boolean | | 
-| | 10005 | Charging active | boolean | | 
-**01000002** | | Temperature indoor | | 6/min | * Unit: Celcius <br>* Resolution: <= 1 C
-| | tempavg | Temperature indoor average | float | | | 
-| | tempfront | Temperature indoor front | float | | |
-| | tempmiddle | Temperature indoor middle | float | | |
-| | temprear | Temperature indoor rear | float | | |
-**01000005** | | SOC | float | 1/min | 
-**01000006** | | Transmission mode | combustion/electric | onChange | Intended for hybrid vehicles
-**01000007** | | Windscreen wiper active | boolean | onChange | Taken to represent a measurement of the ground truth binary rainfall state, given that it is a better predictor of the binary rainfall state than radar- or gauge-based measurements
-**01000008** | | Accelerometry | | 6/min | * Bandwidth: >= 100 hz <br>* Unit: g <br>* Resolution: <= 0.01 g
-| | xmin | Min x value last interval | float | | |
-| | xmax | Max x value last interval | float | | |
-| | xavg | Average x value last interval | float | | |
-| | ymin | Min y value last interval | float | | |
-| | ymax | Max y value last interval | float | | |
-| | yavg | Average y value last interval | float | | |
-| | zmin | Min z value last interval | float | | |
-| | zmax | Max z value last interval | float | | |
-| | zavg | Average z value last interval | float | | |
-**01000009** | | Temperature outdoor | float | 1/min |* Unit: Celcius <br>* Resolution: <= 1 C <br>* Measured at front of vehicle as near as possible to the ground
-**0100000A** | | Accumulated energy consumption | float | 1/min | * Energy consumed <br>* Including HVAC <br>* Unit: kWh
+See topics with specific id for more information.
+
+| Telemetry ID | Telemetry Type                                                                                                                    | 
+|:------------:|-----------------------------------------------------------------------------------------------------------------------------------|
+|   0001FF25   | [Charger (deprecated)](json-schemas/sensors/telemetry/charger/charger.md)                                                         |
+|   01000002   | [Temperature indoor](json-schemas/sensors/telemetry/temperature-indoor/temperature-indoor.md)                                     |
+|   01000005   | [State of charge](json-schemas/sensors/telemetry/state-of-charge/state-of-charge.md)                                              |
+|   01000006   | [Transmission mode](json-schemas/sensors/telemetry/transmission-mode/transmission-mode.md)                                        |
+|   01000007   | [Windscreen wiper active](json-schemas/sensors/telemetry/windscreeen-wiper-active/windscreeen-wiper-active.md)                    |
+|   01000008   | [Accelerometry](json-schemas/sensors/telemetry/accelerometry/accelerometry.md)                                                    |
+|   01000009   | [Temperature outdoor](json-schemas/sensors/telemetry/temperature-outdoor/temperature-outdoor.md)                                  |
+|   0100000A   | [Accumulated energy consumption](json-schemas/sensors/telemetry/accumulated-energy-consumption/accumulated-energy-consumption.md) |

--- a/asyncapi/json-schemas/sensors/telemetry/telemetry.meta.json
+++ b/asyncapi/json-schemas/sensors/telemetry/telemetry.meta.json
@@ -3,9 +3,9 @@
   "mqtt": {
     "qos": 0,
     "retain": false,
-    "topic": "ruter/{operatorId}/{vehicleId}/adt/v3/sensors/telemetry/{sensorId}",
+    "topic": "ruter/{operatorId}/{vehicleId}/adt/v3/sensors/telemetry/{telemetryId}",
     "params": [
-      "sensorId"
+      "telemetryId"
     ]
   }
 }

--- a/asyncapi/json-schemas/sensors/telemetry/temperature-indoor/temperature-indoor-01.example.json
+++ b/asyncapi/json-schemas/sensors/telemetry/temperature-indoor/temperature-indoor-01.example.json
@@ -1,6 +1,7 @@
 {
   "name": "Temperature indoor",
   "payload": {
+    "name": "Temperature indoor",
     "eventTimestamp": "2022-05-09T13:27:59.624Z",
     "traceId": "3841a268-0c03-4588-b476-211be0f26a0d",
     "messageNumber": 1,
@@ -8,26 +9,22 @@
     "payloads": [
       {
         "subid": "tempavg",
-        "name": "Temperature indoor average",
-        "unit": "C",
+        "sensorId": "XB7F-9T2M-L4FC-3R8Q",
         "value": 18.1
       },
       {
         "subid": "tempfront",
-        "name": "Temperature indoor front",
-        "unit": "C",
+        "sensorId": "XB7F-9T2M-L4FC-3R8Q",
         "value": 18.2
       },
       {
         "subid": "tempmiddle",
-        "name": "Temperature indoor middle",
-        "unit": "C",
+        "sensorId": "XB7F-9T2M-L4FC-3R8Q",
         "value": 18.1
       },
       {
         "subid": "temprear",
-        "name": "Temperature indoor rear",
-        "unit": "C",
+        "sensorId": "XB7F-9T2M-L4FC-3R8Q",
         "value": 18.4
       }
     ]

--- a/asyncapi/json-schemas/sensors/telemetry/temperature-indoor/temperature-indoor.md
+++ b/asyncapi/json-schemas/sensors/telemetry/temperature-indoor/temperature-indoor.md
@@ -1,0 +1,29 @@
+### Temperature Indoor Message
+
+| Field         | Value                                                                                                     |
+|---------------|-----------------------------------------------------------------------------------------------------------|
+| Central Topic | ruter/{operatorId}/{vehicleId}/adt/v3/sensors/telemetry/01000002                                          |
+| Schema        | [ telemetry.json ](json-schemas/sensors/telemetry/telemetry.json)                                         |
+| Producer      | PTO                                                                                                       |
+| Consumer      | Ruter BO                                                                                                  |
+| Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version. | 
+
+Describes the interior temperature of the vehicle.
+
+#### Data specification
+
+- **Frequency:** 6 times per minute (6/min)
+- **Unit:** Degrees Celsius (°C)
+- **Resolution:** <= 1°C
+
+#### Payload details
+
+- **Name:** Temperature indoor
+- **ID:** 01000002
+
+| Sub ID     | Value Type | Description                  |
+|:-----------|:-----------|:-----------------------------|
+| tempavg    | float      | Average interior temperature |
+| tempfront  | float      | Front interior temperature   |
+| tempmiddle | float      | Middle interior temperature  |
+| temprear   | float      | Rear interior temperature    |

--- a/asyncapi/json-schemas/sensors/telemetry/temperature-indoor/temperature-indoor.md
+++ b/asyncapi/json-schemas/sensors/telemetry/temperature-indoor/temperature-indoor.md
@@ -12,7 +12,7 @@ Describes the interior temperature of the vehicle.
 
 #### Data specification
 
-- **Frequency:** 6 times per minute (6/min)
+- **Message frequency:** 6 times per minute (6/min)
 - **Unit:** Degrees Celsius (°C)
 - **Resolution:** <= 1°C
 

--- a/asyncapi/json-schemas/sensors/telemetry/temperature-indoor/temperature-indoor.meta.json
+++ b/asyncapi/json-schemas/sensors/telemetry/temperature-indoor/temperature-indoor.meta.json
@@ -1,0 +1,8 @@
+{
+  "mode": "publish",
+  "mqtt": {
+    "qos": 0,
+    "retain": false,
+    "topic": "ruter/{operatorId}/{vehicleId}/adt/v3/sensors/telemetry/01000002"
+  }
+}

--- a/asyncapi/json-schemas/sensors/telemetry/temperature-outdoor/temperature-outdoor-01.example.json
+++ b/asyncapi/json-schemas/sensors/telemetry/temperature-outdoor/temperature-outdoor-01.example.json
@@ -1,15 +1,15 @@
 {
-  "name": "Accumulated energy consumption",
+  "name": "Temperature outdoor",
   "payload": {
     "eventTimestamp": "2022-05-09T13:27:59.624Z",
     "traceId": "3841a268-0c03-4588-b476-211be0f26a0d",
     "messageNumber": 1,
-    "id": "0100000A",
+    "id": "01000009",
     "payloads": [
       {
-        "name": "Accumulated energy consumption",
-        "unit": "kWh",
-        "value": 0.972
+        "name": "Temperature outdoor",
+        "sensorId": "XB7F-9T2M-L4FC-3R8Q",
+        "value": 20.7
       }
     ]
   }

--- a/asyncapi/json-schemas/sensors/telemetry/temperature-outdoor/temperature-outdoor.md
+++ b/asyncapi/json-schemas/sensors/telemetry/temperature-outdoor/temperature-outdoor.md
@@ -1,0 +1,25 @@
+### Temperature Outdoor Message
+| Field         | Value                                                                                                     |
+|---------------|-----------------------------------------------------------------------------------------------------------|
+| Central Topic | ruter/{operatorId}/{vehicleId}/adt/v3/sensors/telemetry/01000009                                       |
+| Schema        | [ telemetry.json ](json-schemas/sensors/telemetry/telemetry.json)                                         |
+| Producer      | PTO                                                                                                       |
+| Consumer      | Ruter BO                                                                                                  |
+| Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version. | 
+
+Measures the external temperature around the vehicle.
+
+#### Data specification
+
+- **Frequency:** Once per minute (1/min)
+- **Unit:** Degrees Celsius (°C)
+- **Resolution:** <= 1°C
+
+#### Payload details
+
+- **Name:** Temperature outdoor
+- **ID:** 01000009
+
+| Sub ID | Name                | Value Type | Description                      |
+|:-------|:--------------------|:-----------|:---------------------------------|
+| N/A    | Temperature outdoor | float      | External temperature measurement |

--- a/asyncapi/json-schemas/sensors/telemetry/temperature-outdoor/temperature-outdoor.md
+++ b/asyncapi/json-schemas/sensors/telemetry/temperature-outdoor/temperature-outdoor.md
@@ -11,7 +11,7 @@ Measures the external temperature around the vehicle.
 
 #### Data specification
 
-- **Frequency:** Once per minute (1/min)
+- **Message frequency:** Once per minute (1/min)
 - **Unit:** Degrees Celsius (°C)
 - **Resolution:** <= 1°C
 

--- a/asyncapi/json-schemas/sensors/telemetry/temperature-outdoor/temperature-outdoor.meta.json
+++ b/asyncapi/json-schemas/sensors/telemetry/temperature-outdoor/temperature-outdoor.meta.json
@@ -1,0 +1,8 @@
+{
+  "mode": "publish",
+  "mqtt": {
+    "qos": 0,
+    "retain": false,
+    "topic": "ruter/{operatorId}/{vehicleId}/adt/v3/sensors/telemetry/01000009"
+  }
+}

--- a/asyncapi/json-schemas/sensors/telemetry/transmission-mode/transmission-mode-01.example.json
+++ b/asyncapi/json-schemas/sensors/telemetry/transmission-mode/transmission-mode-01.example.json
@@ -1,15 +1,15 @@
 {
-  "name": "SOC",
+  "name": "Transmission mode",
   "payload": {
     "eventTimestamp": "2022-05-09T13:27:59.624Z",
     "traceId": "3841a268-0c03-4588-b476-211be0f26a0d",
     "messageNumber": 1,
-    "id": "01000005",
+    "id": "01000006",
     "payloads": [
       {
-        "name": "SOC",
-        "unit": "%",
-        "value": 20.3
+        "name": "Transmission mode",
+        "sensorId": "XB7F-9T2M-L4FC-3R8Q",
+        "value": "electric"
       }
     ]
   }

--- a/asyncapi/json-schemas/sensors/telemetry/transmission-mode/transmission-mode.md
+++ b/asyncapi/json-schemas/sensors/telemetry/transmission-mode/transmission-mode.md
@@ -12,7 +12,7 @@ Intended for hybrid vehicles. Describes the current transmission mode of the veh
 
 #### Data specification
 
-- **Frequency:** On change
+- **Message frequency:** On change
 - **Value:** `COMBUSTION` or `ELECTRIC`
 
 #### Payload details

--- a/asyncapi/json-schemas/sensors/telemetry/transmission-mode/transmission-mode.md
+++ b/asyncapi/json-schemas/sensors/telemetry/transmission-mode/transmission-mode.md
@@ -1,0 +1,25 @@
+### Transmission Mode Message
+
+| Field         | Value                                                                                                     |
+|---------------|-----------------------------------------------------------------------------------------------------------|
+| Central Topic | ruter/{operatorId}/{vehicleId}/adt/v3/sensors/telemetry/01000006                                          |
+| Schema        | [ telemetry.json ](json-schemas/sensors/telemetry/telemetry.json)                                         |
+| Producer      | PTO                                                                                                       |
+| Consumer      | Ruter BO                                                                                                  |
+| Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version. | 
+
+Intended for hybrid vehicles. Describes the current transmission mode of the vehicle.
+
+#### Data specification
+
+- **Frequency:** On change
+- **Value:** `COMBUSTION` or `ELECTRIC`
+
+#### Payload details
+
+- **Name:** Transmission mode
+- **ID:** 01000006
+
+| Sub ID | Name              | Value Type | Description                                                                |
+|--------|-------------------|------------|----------------------------------------------------------------------------|
+| N/A    | Transmission mode | string     | Current transmisison mode, should be either **COMBUSTION** or **ELECTRIC** |

--- a/asyncapi/json-schemas/sensors/telemetry/transmission-mode/transmission-mode.meta.json
+++ b/asyncapi/json-schemas/sensors/telemetry/transmission-mode/transmission-mode.meta.json
@@ -1,0 +1,8 @@
+{
+  "mode": "publish",
+  "mqtt": {
+    "qos": 0,
+    "retain": false,
+    "topic": "ruter/{operatorId}/{vehicleId}/adt/v3/sensors/telemetry/01000006"
+  }
+}

--- a/asyncapi/json-schemas/sensors/telemetry/windscreen-wiper-active/windscreen-wiper-active-01.example.json
+++ b/asyncapi/json-schemas/sensors/telemetry/windscreen-wiper-active/windscreen-wiper-active-01.example.json
@@ -1,15 +1,15 @@
 {
-  "name": "Temperature outdoor",
+  "name": "Windscreen wiper active",
   "payload": {
     "eventTimestamp": "2022-05-09T13:27:59.624Z",
     "traceId": "3841a268-0c03-4588-b476-211be0f26a0d",
     "messageNumber": 1,
-    "id": "01000009",
+    "id": "01000007",
     "payloads": [
       {
-        "name": "Temperature outdoor",
-        "unit": "C",
-        "value": 20.7
+        "name": "Windscreen wiper active",
+        "sensorId": "XB7F-9T2M-L4FC-3R8Q",
+        "value": true
       }
     ]
   }

--- a/asyncapi/json-schemas/sensors/telemetry/windscreen-wiper-active/windscreen-wiper-active.md
+++ b/asyncapi/json-schemas/sensors/telemetry/windscreen-wiper-active/windscreen-wiper-active.md
@@ -12,7 +12,7 @@ Describes the activity of the windscreen wipers.
 
 #### Data specification
 
-- **Frequency:** On change *(for every swipe)*
+- **Message frequency:** On change *(for every swipe)*
 
 #### Payload details
 

--- a/asyncapi/json-schemas/sensors/telemetry/windscreen-wiper-active/windscreen-wiper-active.md
+++ b/asyncapi/json-schemas/sensors/telemetry/windscreen-wiper-active/windscreen-wiper-active.md
@@ -1,0 +1,24 @@
+### Windscreen Wiper Active Message
+
+| Field         | Value                                                                                                     |
+|---------------|-----------------------------------------------------------------------------------------------------------|
+| Central Topic | ruter/{operatorId}/{vehicleId}/adt/v3/sensors/telemetry/01000007                                          |
+| Schema        | [ telemetry.json ](json-schemas/sensors/telemetry/telemetry.json)                                         |
+| Producer      | PTO                                                                                                       |
+| Consumer      | Ruter BO                                                                                                  |
+| Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version. | 
+
+Describes the activity of the windscreen wipers.
+
+#### Data specification
+
+- **Frequency:** On change *(for every swipe)*
+
+#### Payload details
+
+- **Name:** Windscreen wiper active
+- **Id:** 01000007
+
+| Sub ID | Name                    | Value Type | Description                                                     |
+|--------|-------------------------|------------|-----------------------------------------------------------------|
+| N/A    | Windscreen wiper active | boolean    | Should send a message with value true for every swipe performed |

--- a/asyncapi/json-schemas/sensors/telemetry/windscreen-wiper-active/windscreen-wiper-active.meta.json
+++ b/asyncapi/json-schemas/sensors/telemetry/windscreen-wiper-active/windscreen-wiper-active.meta.json
@@ -1,0 +1,8 @@
+{
+  "mode": "publish",
+  "mqtt": {
+    "qos": 0,
+    "retain": false,
+    "topic": "ruter/{operatorId}/{vehicleId}/adt/v3/sensors/telemetry/01000007"
+  }
+}

--- a/asyncapi/json-schemas/sensors/temperature-water/temperature-water-01.example.json
+++ b/asyncapi/json-schemas/sensors/temperature-water/temperature-water-01.example.json
@@ -1,0 +1,10 @@
+{
+  "name": "Temperature water",
+  "payload": {
+    "eventTimestamp": "2022-05-09T13:27:59.624Z",
+    "traceId": "3841a268-0c03-4588-b476-211be0f26a0d",
+    "messageNumber": 1,
+    "sensorId": "XB7F-9T2M-L4KP-3R8Q",
+    "value:": 18.5
+  }
+}

--- a/asyncapi/json-schemas/sensors/temperature-water/temperature-water.json
+++ b/asyncapi/json-schemas/sensors/temperature-water/temperature-water.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.ruter.no/adt/ota/api/v3.0/sensors/telemetry/temperature-water.json",
+  "type": "object",
+  "title": "Temperature Water",
+  "description": "Schema for water temperature sensor data",
+  "required": [
+    "eventTimestamp",
+    "traceId",
+    "messageNumber",
+    "sensorId",
+    "value"
+  ],
+  "properties": {
+    "eventTimestamp": {
+      "type": "string",
+      "description": "ISO 8601 timestamp of when the measurement was taken"
+    },
+    "traceId": {
+      "type": "string",
+      "description": "Unique identifier for tracing this message"
+    },
+    "messageNumber": {
+      "type": "integer",
+      "description": "Sequence number, increased by one for each new message"
+    },
+    "sensorId": {
+      "type": "string",
+      "description": "Unique identifier for the sensor. Typically the serial number (S/N) from the sensor."
+    },
+    "value": {
+      "type": "number",
+      "description": "Water temperature in Celsius"
+    }
+  },
+  "additionalProperties": true
+}

--- a/asyncapi/json-schemas/sensors/temperature-water/temperature-water.md
+++ b/asyncapi/json-schemas/sensors/temperature-water/temperature-water.md
@@ -1,0 +1,19 @@
+### Temperature Water Message
+
+| Field         | Value                                                                                                    |
+|---------------|----------------------------------------------------------------------------------------------------------|
+| Central Topic | ruter/{operatorId}/{vehicleId}/adt/v3/sensors/temperature/water                                          |
+| Schema        | [ temperature-water.json ](json-schemas/sensors/temperature-water/temperature-water.json)                |
+| Producer      | PTO                                                                                                      |
+| Consumer      | Ruter BO                                                                                                 |
+| Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version. | 
+
+Describes the water temperature in Celsius, measured 1 meter below the water surface. The value should be a float with a
+resolution of 1°C or better.
+
+#### Data specification
+
+- Frequency: 1 message per minute (1/min)
+- Unit: Celsius
+- Resolution: <= 1°C
+- Measurement depth: 1 meter below the water surface

--- a/asyncapi/json-schemas/sensors/temperature-water/temperature-water.md
+++ b/asyncapi/json-schemas/sensors/temperature-water/temperature-water.md
@@ -13,7 +13,7 @@ resolution of 1°C or better.
 
 #### Data specification
 
-- Frequency: 1 message per minute (1/min)
+- Message frequency: 1 message per minute (1/min)
 - Unit: Celsius
 - Resolution: <= 1°C
 - Measurement depth: 1 meter below the water surface

--- a/asyncapi/json-schemas/sensors/temperature-water/temperature-water.meta.json
+++ b/asyncapi/json-schemas/sensors/temperature-water/temperature-water.meta.json
@@ -1,0 +1,8 @@
+{
+  "mode": "publish",
+  "mqtt": {
+    "qos": 0,
+    "retain": false,
+    "topic": "ruter/{operatorId}/{vehicleId}/adt/v3/sensors/temperature/water"
+  }
+}

--- a/asyncapi/json-schemas/sensors/wind/wind-01.example.json
+++ b/asyncapi/json-schemas/sensors/wind/wind-01.example.json
@@ -1,0 +1,13 @@
+{
+  "name": "Wind",
+  "payload": {
+    "eventTimestamp": "2023-05-10T14:30:00Z",
+    "traceId": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+    "messageNumber": 42,
+    "sensorId": "XB7F-9T2M-L4FC-3R8Q",
+    "speed": 2.7,
+    "direction": 225
+  }
+}
+
+

--- a/asyncapi/json-schemas/sensors/wind/wind.json
+++ b/asyncapi/json-schemas/sensors/wind/wind.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.ruter.no/adt/ota/api/v3.3/sensors/wind.json",
+  "type": "object",
+  "title": "Wind",
+  "description": "Schema for wind speed and direction sensor data",
+  "required": [
+    "eventTimestamp",
+    "traceId",
+    "messageNumber",
+    "sensorId",
+    "speed",
+    "direction"
+  ],
+  "properties": {
+    "eventTimestamp": {
+      "type": "string",
+      "description": "ISO 8601 timestamp of when the measurement was taken"
+    },
+    "traceId": {
+      "type": "string",
+      "description": "Unique identifier for tracing this message"
+    },
+    "messageNumber": {
+      "type": "integer",
+      "description": "Sequence number, increased by one for each new message"
+    },
+    "sensorId": {
+      "type": "string",
+      "description": "Unique identifier for the sensor. Typically the serial number (S/N) from the sensor."
+    },
+    "speed": {
+      "type": "number",
+      "description": "Wind speed in meters per second (m/s)"
+    },
+    "direction": {
+      "type": "integer",
+      "description": "Wind direction in degrees from true north (0-359°)"
+    }
+  },
+  "additionalProperties": true
+}

--- a/asyncapi/json-schemas/sensors/wind/wind.md
+++ b/asyncapi/json-schemas/sensors/wind/wind.md
@@ -1,0 +1,28 @@
+### Wind Message
+
+| Field         | Value                                                                                                     |
+|:--------------|:----------------------------------------------------------------------------------------------------------|
+| Central Topic | ruter/{operatorId}/{vehicleId}/adt/v3/sensors/wind                                                        |
+| Schema        | [ wind.json ](json-schemas/sensors/wind/wind.json)                                                        |
+| Producer      | PTO                                                                                                       |
+| Consumer      | Ruter BO                                                                                                  |
+| Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version. |
+
+Describes the wind speed and direction measured on the vehicle. The wind speed should be reported in meters per second (
+m/s) as a float with a resolution of 0.1 m/s or better. The wind direction should be reported in degrees from true
+north (0-359°) as an integer.
+
+#### Data specification
+
+Frequency:
+- 1 message per minute (1/min)
+
+Properties:
+- speed
+  - Unit: meters per second (m/s)
+  - Resolution: <= 0.1 m/s
+
+- direction:
+  - Unit: degrees from true north
+  - Range: 0-359°
+  - Resolution: 1°

--- a/asyncapi/json-schemas/sensors/wind/wind.md
+++ b/asyncapi/json-schemas/sensors/wind/wind.md
@@ -14,7 +14,7 @@ north (0-359°) as an integer.
 
 #### Data specification
 
-Frequency:
+Message frequency:
 - 1 message per minute (1/min)
 
 Properties:

--- a/asyncapi/json-schemas/sensors/wind/wind.meta.json
+++ b/asyncapi/json-schemas/sensors/wind/wind.meta.json
@@ -1,0 +1,8 @@
+{
+  "mode": "publish",
+  "mqtt": {
+    "qos": 0,
+    "retain": false,
+    "topic": "ruter/{operatorId}/{vehicleId}/adt/v3/sensors/wind"
+  }
+}


### PR DESCRIPTION
# ADT 3.3 changes for telemetry

This PR introduces several updates and additions to the telemetry system in ADT 3.3:

## Key Changes

1. Restructured the telemetry topic to use `telemetryId` instead of `sensorId`.
2. Added new telemetry types:
   - Charging
   - Temperature Water
   - Wind
3. Updated existing telemetry types with more detailed specifications:
   - Accelerometry
   - State of Charge
   - Temperature Indoor
   - Temperature Outdoor
   - Transmission Mode
   - Windscreen Wiper Active
4. Deprecated the Charger telemetry (0001FF25) in favor of the new Charging topic.
5. Updated the telemetry schema to support both single-sensor and multi-sensor payloads.
6. Added `sensorId` field to payloads for better sensor identification.
7. Split generic telemetry operation `sensors/telemetry/{sensorId}` into individual operations to make the documentation more clear.

## Updated Telemetry Operations

- sensors/telemetry/{telemetryId} (Generic/FMS)
- sensors/telemetry/0001FF25 (Charger)
- sensors/telemetry/01000002 (Temperature Indoor)
- sensors/telemetry/01000005 (State of Charge)
- sensors/telemetry/01000006 (Transmission Mode)
- sensors/telemetry/01000007 (Windscreen Wiper Active)
- sensors/telemetry/01000008 (Accelerometry)
- sensors/telemetry/01000009 (Temperature Outdoor)
- sensors/telemetry/0100000A (Accumulated Energy Consumption)

## Documentation Updates

- Added detailed markdown files for each telemetry type, including data specifications and payload details.
- Updated the main telemetry documentation to reflect the new structure and available telemetry types.

## Schema Updates

- Updated JSON schemas for all telemetry types to align with the new structure.
- Added example JSON files for each telemetry type to illustrate proper usage.