### PR TITLE
DPPAX-628: Change the description to "since the last APC message was …

### DIFF
--- a/asyncapi/json-schemas/sensors/apc/apc.json
+++ b/asyncapi/json-schemas/sensors/apc/apc.json
@@ -40,12 +40,12 @@
     "alightingCount": {
       "$id": "#/properties/alightingCount",
       "type": "number",
-      "description": "Total number of alighting passengers detected by this sensor since last reset."
+      "description": "Total number of alighting passengers detected by this sensor since the last APC message was produced."
     },
     "boardingCount": {
       "$id": "#/properties/boardingCount",
       "type": "number",
-      "description": "Total number of boarding passengers detected by this sensor since last reset."
+      "description": "Total number of boarding passengers detected by this sensor since the last APC message was produced."
     },
     "categoryActivities": {
       "$id": "#/properties/categoryActivities",
@@ -73,11 +73,11 @@
           },
           "alightingCount": {
             "type": "number",
-            "description": "Number of alighting of this category detected by this sensor since last reset."
+            "description": "Number of alighting of this category detected by this sensor since the last APC message was produced."
           },
           "boardingCount": {
             "type": "number",
-            "description": "Number of boarding of this category detected by this sensor since last reset."
+            "description": "Number of boarding of this category detected by this sensor since the last APC message was produced."
           }
         }
       }


### PR DESCRIPTION
…produced" instead of "reset". The reset point is after each message is produced