### PR TITLE
4.x add separate DPI command response topic

### DIFF
--- a/asyncapi/asyncapi.yml
+++ b/asyncapi/asyncapi.yml
@@ -427,7 +427,7 @@ channels:
   pe/dpi/command_response:
     description:
       $ref: json-schemas/pe/dpi/command_response/dpi-command_response.md
-    publish:
+    subscribe:
       message:
         name: DpiCommandResponse
         schemaFormat: application/schema+json;version=draft-07

--- a/asyncapi/asyncapi.yml
+++ b/asyncapi/asyncapi.yml
@@ -427,7 +427,7 @@ channels:
   pe/dpi/command_response:
     description:
       $ref: json-schemas/pe/dpi/command_response/dpi-command_response.md
-    subscribe:
+    publish:
       message:
         name: DpiCommandResponse
         schemaFormat: application/schema+json;version=draft-07

--- a/asyncapi/asyncapi.yml
+++ b/asyncapi/asyncapi.yml
@@ -424,6 +424,21 @@ channels:
           mqtt:
             qos: 1
             retain: false
+  pe/dpi/command_response:
+    description:
+      $ref: json-schemas/pe/dpi/command_response/dpi-command_response.md
+    publish:
+      message:
+        name: DpiCommandResponse
+        schemaFormat: application/schema+json;version=draft-07
+        payload:
+          $ref: json-schemas/pe/dpi/command_response/dpi-command_response.json
+        examples:
+          - $ref: json-schemas/pe/dpi/command_response/dpi-command_response.example.json
+        bindings:
+          mqtt:
+            qos: 1
+            retain: false
   pe/sales/diagnostics:
     description:
       $ref: json-schemas/pe/sales/diagnostics/sales-diagnostics.md

--- a/asyncapi/json-schemas/pe/dpi/command_response/dpi-command_response.example.json
+++ b/asyncapi/json-schemas/pe/dpi/command_response/dpi-command_response.example.json
@@ -1,0 +1,12 @@
+{
+  "name": "DPI Command response",
+  "payload": {
+    "eventTimestamp": "2025-10-31T12:45:50.749Z",
+    "traceId": "3841a268-0c03-4588-b476-211be0f26a0d",
+    "command": "GET_FEATURES",
+    "payload": {
+      "feature_1": false,
+      "feature_2": true
+    }
+  }
+}

--- a/asyncapi/json-schemas/pe/dpi/command_response/dpi-command_response.example.json
+++ b/asyncapi/json-schemas/pe/dpi/command_response/dpi-command_response.example.json
@@ -3,6 +3,7 @@
   "payload": {
     "eventTimestamp": "2025-10-31T12:45:50.749Z",
     "traceId": "3841a268-0c03-4588-b476-211be0f26a0d",
+    "correlationId": "211be0f8-2901-a768-0b13-3841a26826a0",
     "command": "GET_FEATURES",
     "payload": {
       "feature_1": false,

--- a/asyncapi/json-schemas/pe/dpi/command_response/dpi-command_response.json
+++ b/asyncapi/json-schemas/pe/dpi/command_response/dpi-command_response.json
@@ -5,7 +5,13 @@
   "type": "object",
   "title": "DpiCommandResponse",
   "description": "Message sent from vehicle as response to DPI commands",
-  "required": ["eventTimestamp", "traceId", "command", "payload"],
+  "required": [
+    "eventTimestamp",
+    "traceId",
+    "correlationId",
+    "command",
+    "payload"
+  ],
   "additionalProperties": true,
   "properties": {
     "eventTimestamp": {
@@ -18,6 +24,11 @@
       "$id": "#/properties/traceId",
       "type": "string",
       "description": "A unique identifier - UUID"
+    },
+    "correlationId": {
+      "$id": "#/properties/correlationId",
+      "type": "string",
+      "description": "The traceId of the DPICommand message that this is a response to. This is used to correlate the command with the response."
     },
     "command": {
       "$id": "#/properties/command",

--- a/asyncapi/json-schemas/pe/dpi/command_response/dpi-command_response.json
+++ b/asyncapi/json-schemas/pe/dpi/command_response/dpi-command_response.json
@@ -1,0 +1,34 @@
+{
+  "definitions": {},
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schemas.ruter.no/adt/ota/api/v4.x/pe/dpi/command/dpi-command_response.json",
+  "type": "object",
+  "title": "DpiCommandResponse",
+  "description": "Message sent from vehicle as response to DPI commands",
+  "required": ["eventTimestamp", "traceId", "command", "payload"],
+  "additionalProperties": true,
+  "properties": {
+    "eventTimestamp": {
+      "$id": "#/properties/eventTimestamp",
+      "type": "string",
+      "description": "As specified in the [ADT documentation.](https://adt.transhub.io)",
+      "format": "date-time"
+    },
+    "traceId": {
+      "$id": "#/properties/traceId",
+      "type": "string",
+      "description": "A unique identifier - UUID"
+    },
+    "command": {
+      "$id": "#/properties/command",
+      "command": "string",
+      "description": "The command that was executed"
+    },
+    "payload": {
+      "$id": "#/properties/payload",
+      "type": "object",
+      "description": "Command response body",
+      "additionalProperties": true
+    }
+  }
+}

--- a/asyncapi/json-schemas/pe/dpi/command_response/dpi-command_response.md
+++ b/asyncapi/json-schemas/pe/dpi/command_response/dpi-command_response.md
@@ -1,0 +1,13 @@
+### Command response message
+
+Responses generated from requests sent on `/pe/dpi/command`
+
+| Field         | Value                                                                                                              |
+| ------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Central Topic | {operatorId}/ruter/{vehicleId}/adt/v4/pe/dpi/command_response                                                      |
+| Schema        | [ dpi-command_response.json ](json-schemas/pe/dpi/command/dpi-command_response.json)                               |
+| Producer      | [Ruter DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                        |
+| Consumer      | [Ruter DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                        |
+| Service Level | ⛔ Ruter internal API. No restrictions apply. API may be removed or modified freely by Ruter within major version. |
+
+This API is reserved for command and control messages for debugging purposes of DPI client.

--- a/asyncapi/json-schemas/pe/dpi/command_response/dpi-command_response.md
+++ b/asyncapi/json-schemas/pe/dpi/command_response/dpi-command_response.md
@@ -4,7 +4,7 @@ Responses generated from requests sent on `/pe/dpi/command`
 
 | Field         | Value                                                                                                              |
 | ------------- | ------------------------------------------------------------------------------------------------------------------ |
-| Central Topic | {operatorId}/ruter/{vehicleId}/adt/v4/pe/dpi/command_response                                                      |
+| Central Topic | ruter/{operatorId}/{vehicleId}/adt/v4/pe/dpi/command_response                                                      |
 | Schema        | [ dpi-command_response.json ](json-schemas/pe/dpi/command/dpi-command_response.json)                               |
 | Producer      | [Ruter DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                        |
 | Consumer      | [Ruter DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                        |

--- a/asyncapi/json-schemas/pe/dpi/command_response/dpi-command_response.meta.json
+++ b/asyncapi/json-schemas/pe/dpi/command_response/dpi-command_response.meta.json
@@ -1,0 +1,8 @@
+{
+  "mode": "subscribe",
+  "mqtt": {
+    "retain": false,
+    "qos": 1,
+    "topic": "{operatorId}/ruter/{vehicleId}/adt/v4/pe/dpi/command_response"
+  }
+}

--- a/asyncapi/json-schemas/pe/dpi/command_response/dpi-command_response.meta.json
+++ b/asyncapi/json-schemas/pe/dpi/command_response/dpi-command_response.meta.json
@@ -1,8 +1,8 @@
 {
-  "mode": "subscribe",
+  "mode": "publish",
   "mqtt": {
     "retain": false,
     "qos": 1,
-    "topic": "{operatorId}/ruter/{vehicleId}/adt/v4/pe/dpi/command_response"
+    "topic": "ruter/{operatorId}/{vehicleId}/adt/v4/pe/dpi/command_response"
   }
 }


### PR DESCRIPTION
Debug messages triggered by requests sent on `pe/dpi/command` have historically been sent on `pe/dpi/diagnostics`

This PR suggests separating this traffic to a dedicated topic `pe/dpi/command_response`