### PR TITLE
doc: Update consumers, producers and maintainers

### DIFF
--- a/asyncapi/json-schemas/di/available-destination-displays/available-destination-displays.md
+++ b/asyncapi/json-schemas/di/available-destination-displays/available-destination-displays.md
@@ -4,8 +4,8 @@
 |---------------|-----------------------------------------------------------------------------------------------------------------------------|
 | Central Topic | {operatorId}/{authorityId}/backoffice/adt/v4/di/available_destination_displays                                              |
 | Schema        | [ available-destination-displays.json ](json-schemas/di/available-destination-displays/available-destination-displays.json) |
-| Maintainer    | PTA Backoffice                                                                                                              |
-| Producer      | [PTA Assignment](https://github.com/orgs/RuterNo/teams/assignment)                                                          |
+| Maintainer    | [Assignment](https://github.com/orgs/RuterNo/teams/assignment)                                                              |
+| Producer      | [Assignment](https://github.com/orgs/RuterNo/teams/assignment)                                                              |
 | Consumer      | PTO                                                                                                                         |
 | Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version.                    |
 

--- a/asyncapi/json-schemas/di/available-destination-displays/available-destination-displays.meta.json
+++ b/asyncapi/json-schemas/di/available-destination-displays/available-destination-displays.meta.json
@@ -14,6 +14,6 @@
     "pto"
   ],
   "maintainers": [
-    "pta"
+    "assignment"
   ]
 }

--- a/asyncapi/json-schemas/di/operational_message_to_driver/operational-message-to-driver.md
+++ b/asyncapi/json-schemas/di/operational_message_to_driver/operational-message-to-driver.md
@@ -3,8 +3,8 @@
 |---------------|--------------------------------------------------------------------------------------------------------------------------|
 | Central Topic | {operatorId}/{authorityId}/{vehicleId}/adt/v4/di/operational_message_to_driver                                           |
 | Schema        | [ operational-message-to-driver.json ](json-schemas/di/operational_message_to_driver/operational-message-to-driver.json) |
-| Maintainer    | PTA Backoffice                                                                                                           |
-| Producer      | PTA Backoffice                                                                                                           |
+| Maintainer    | PTA                                                                                                                      |
+| Producer      | PTA                                                                                                                      |
 | Consumer      | PTO                                                                                                                      |
 | Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version.                 |
 

--- a/asyncapi/json-schemas/di/override_attempt/destination_display/destination-display-override.md
+++ b/asyncapi/json-schemas/di/override_attempt/destination_display/destination-display-override.md
@@ -3,9 +3,9 @@
 |---------------|-------------------------------------------------------------------------------------------------------------------------------|
 | Central Topic | {authorityId}/{operatorId}/{vehicleId}/adt/v4/di/override_attempt/destination_display                                         |
 | Schema        | [ destination-display-override.json ](json-schemas/di/override_attempt/destination_display/destination-display-override.json) |
-| Maintainer    | PTA Backoffice                                                                                                                |
+| Maintainer    | [Assignment](https://github.com/orgs/RuterNo/teams/assignment)                                                                |
 | Producer      | PTO                                                                                                                           |
-| Consumer      | [PTA Assignment](https://github.com/orgs/RuterNo/teams/assignment)                                                            |
+| Consumer      | [Assignment](https://github.com/orgs/RuterNo/teams/assignment)                                                                |
 | Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version.                     |
 
 To construct a message, refer to the Available Destination Displays Message list and ensure that all fields provided in 

--- a/asyncapi/json-schemas/di/override_attempt/destination_display/destination-display-override.meta.json
+++ b/asyncapi/json-schemas/di/override_attempt/destination_display/destination-display-override.meta.json
@@ -13,6 +13,6 @@
     "assignment"
   ],
   "maintainers": [
-    "pta"
+    "assignment"
   ]
 }

--- a/asyncapi/json-schemas/pe/active-cab/active-cab.md
+++ b/asyncapi/json-schemas/pe/active-cab/active-cab.md
@@ -3,7 +3,7 @@
 |---------------|-----------------------------------------------------------------------------------------------------------|
 | Central Topic | {authorityId}/{operatorId}/{vehicleId}/adt/v4/pe/active_cab                                               |
 | Schema        | [ active-cab.json ](json-schemas/pe/active-cab/active-cab.json)                                           |
-| Maintainer    | PTA Backoffice                                                                                            |
+| Maintainer    | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                     |
 | Producer      | PTO                                                                                                       |
-| Consumer      | PTA Backoffice                                                                                            |
+| Consumer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team), [Progress](https://github.com/orgs/RuterNo/teams/progress)|
 | Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version. |

--- a/asyncapi/json-schemas/pe/active-cab/active-cab.meta.json
+++ b/asyncapi/json-schemas/pe/active-cab/active-cab.meta.json
@@ -10,9 +10,9 @@
     "pto"
   ],
   "consumers": [
-    "pta"
+    "dpi, progress"
   ],
   "maintainers": [
-    "pta"
+    "dpi"
   ]
 }

--- a/asyncapi/json-schemas/pe/active-cab/active-cab.meta.json
+++ b/asyncapi/json-schemas/pe/active-cab/active-cab.meta.json
@@ -10,7 +10,7 @@
     "pto"
   ],
   "consumers": [
-    "dpi, progress"
+    "dpi", "progress"
   ],
   "maintainers": [
     "dpi"

--- a/asyncapi/json-schemas/pe/active-cab/active-cab.meta.json
+++ b/asyncapi/json-schemas/pe/active-cab/active-cab.meta.json
@@ -10,7 +10,8 @@
     "pto"
   ],
   "consumers": [
-    "dpi", "progress"
+    "dpi",
+    "progress"
   ],
   "maintainers": [
     "dpi"

--- a/asyncapi/json-schemas/pe/audio/audio.md
+++ b/asyncapi/json-schemas/pe/audio/audio.md
@@ -3,8 +3,8 @@
 |---------------|-----------------------------------------------------------------------------------------------------------|
 | Central Topic | {operatorId}/{authorityId}/{vehicleId}/adt/v4/pe/audio                                                    |
 | Schema        | [ audio.json ](json-schemas/pe/audio/audio.json)                                                          |
-| Maintainer    | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)  |
-| Producer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)  |
+| Maintainer    | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)      |
+| Producer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)      |
 | Consumer      | PTO                                                                                                       |
 | Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version. |
 

--- a/asyncapi/json-schemas/pe/cardreader-diagnostics/vix/vix-cardreader_diagnostics.md
+++ b/asyncapi/json-schemas/pe/cardreader-diagnostics/vix/vix-cardreader_diagnostics.md
@@ -3,9 +3,9 @@
 |---------------|-------------------------------------------------------------------------------------------------------------------|
 | Central Topic | {authorityId}/{operatorId}/{vehicleId}/adt/v4/pe/cardreader_diagnostics/vix/{deviceRef}                           |
 | Schema        | [ vix-cardreader_diagnostics.json ](json-schemas/pe/cardreader-diagnostics/vix/vix-cardreader_diagnostics.json)   |
-| Maintainer    | PTA Backoffice                                                                                                    |
+| Maintainer    | [Betjent salg](https://github.com/orgs/RuterNo/teams/rutersalg)                                                   |
 | Producer      | VIX                                                                                                               |
-| Consumer      | PTA Backoffice                                                                                                    |
+| Consumer      | PTA                                                                                                               |
 | Service Level | ⛔ PTA internal API. No restrictions apply. May be removed or modified freely by the PTA                            |
 
 Diagnostics message sent from any Vix-validator running Ruter-firmware in the vehicle. Can be used by both PTA and PTO to monitor the operational status of these units.

--- a/asyncapi/json-schemas/pe/cardreader-diagnostics/vix/vix-cardreader_diagnostics.meta.json
+++ b/asyncapi/json-schemas/pe/cardreader-diagnostics/vix/vix-cardreader_diagnostics.meta.json
@@ -16,6 +16,6 @@
     "pta"
   ],
   "maintainers": [
-    "pta"
+    "sales"
   ]
 }

--- a/asyncapi/json-schemas/pe/door-lock/door-lock.md
+++ b/asyncapi/json-schemas/pe/door-lock/door-lock.md
@@ -3,9 +3,9 @@
 |---------------|-----------------------------------------------------------------------------------------------------------|
 | Central Topic | {authorityId}/{operatorId}/{vehicleId}/adt/v4/pe/door_lock                                                |
 | Schema        | [ door-lock.json ](json-schemas/pe/door-lock/door-lock.json)                                              |
-| Maintainer    | PTA Backoffice                                                                                            |
+| Maintainer    | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                     |
 | Producer      | PTO                                                                                                       |
-| Consumer      | PTA Backoffice                                                                                            |
+| Consumer      | PTA                                                                                                       |
 | Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version. |
 
 This message is used to track if the vehicle doors are locked or unlocked.

--- a/asyncapi/json-schemas/pe/door-lock/door-lock.meta.json
+++ b/asyncapi/json-schemas/pe/door-lock/door-lock.meta.json
@@ -13,6 +13,6 @@
     "pta"
   ],
   "maintainers": [
-    "pta"
+    "dpi"
   ]
 }

--- a/asyncapi/json-schemas/pe/doors-individually/doors-individually.md
+++ b/asyncapi/json-schemas/pe/doors-individually/doors-individually.md
@@ -3,9 +3,9 @@
 |---------------|-------------------------------------------------------------------------------------------------------------|
 | Central Topic | {authorityId}/{operatorId}/{vehicleId}/adt/v4/pe/doors_individually                                         |
 | Schema        | [ doors-individually.json ](json-schemas/pe/doors-individually/doors-individually.json)                     |
-| Maintainer    | PTA Backoffice                                                                                              |
+| Maintainer    | [Passasjertelling](https://github.com/orgs/RuterNo/teams/passasjertelling)                                  |
 | Producer      | PTO                                                                                                         |
-| Consumer      | PTA Backoffice                                                                                              |
+| Consumer      | PTA                                                                                                         |
 | Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version.   |
 
 This topic is used to track the individual status of doors. One use case is to improve the data quality of APC counts. See also topic sensors/door for status of anyDoorOpen/allDoorsClosed.

--- a/asyncapi/json-schemas/pe/doors-individually/doors-individually.meta.json
+++ b/asyncapi/json-schemas/pe/doors-individually/doors-individually.meta.json
@@ -13,6 +13,6 @@
     "pta"
   ],
   "maintainers": [
-    "pta"
+    "apc"
   ]
 }

--- a/asyncapi/json-schemas/pe/dpi/ack/dpi-acknowledge.md
+++ b/asyncapi/json-schemas/pe/dpi/ack/dpi-acknowledge.md
@@ -3,9 +3,9 @@
 |---------------|-----------------------------------------------------------------------------------------------------------|
 | Central Topic | {authorityId}/{operatorId}/{vehicleId}/adt/v4/pe/dpi/ack                                                  |
 | Schema        | [ dpi-acknowledge.json ](json-schemas/pe/dpi/ack/dpi-acknowledge.json)                                    |
-| Maintainer    | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                 |
-| Producer      | PTO, [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                            |
-| Consumer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                 |
+| Maintainer    | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                     |
+| Producer      | PTO, [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                |
+| Consumer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                     |
 | Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version. |
 
 The DPI Ack topic is used to inform the `PTA Backoffice` about the correct transfer and interpretation of messages to the vehicle.

--- a/asyncapi/json-schemas/pe/dpi/arriving/dpi-arriving.md
+++ b/asyncapi/json-schemas/pe/dpi/arriving/dpi-arriving.md
@@ -3,9 +3,9 @@
 |---------------|-------------------------------------------------------------------------------------------------------------------|
 | Central Topic | {operatorId}/{authorityId}/{vehicleId}/adt/v4/pe/dpi/arriving                                                     |
 | Schema        | [ dpi-arriving.json ](json-schemas/pe/dpi/arriving/dpi-arriving.json)                                             |
-| Maintainer    | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
-| Producer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
-| Consumer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
+| Maintainer    | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
+| Producer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
+| Consumer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
 | Service Level | ⛔ PTA internal API. No restrictions apply. May be removed or modified freely by the PTA                           |
 
 Notice to passengers that the bus is approaching a stop.

--- a/asyncapi/json-schemas/pe/dpi/command/dpi-command.md
+++ b/asyncapi/json-schemas/pe/dpi/command/dpi-command.md
@@ -3,9 +3,9 @@
 |---------------|-------------------------------------------------------------------------------------------------------------------|
 | Central Topic | {operatorId}/{authorityId}/{vehicleId}/adt/v4/pe/dpi/command                                                      |
 | Schema        | [ dpi-command.json ](json-schemas/pe/dpi/command/dpi-command.json)                                                |
-| Maintainer    | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
-| Producer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
-| Consumer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
+| Maintainer    | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
+| Producer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
+| Consumer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
 | Service Level | ⛔ PTA internal API. No restrictions apply. May be removed or modified freely by the PTA                           |
 
 This channels is reserved for command and control messages originated by the PTA. Typical use cases include:

--- a/asyncapi/json-schemas/pe/dpi/command_response/dpi-command_response.md
+++ b/asyncapi/json-schemas/pe/dpi/command_response/dpi-command_response.md
@@ -6,9 +6,9 @@ Responses generated from requests sent on `/pe/dpi/command`
 | ------------- | ------------------------------------------------------------------------------------------------------------------ |
 | Central Topic | {authorityId}/{operatorId}/{vehicleId}/adt/v4/pe/dpi/command_response                                              |
 | Schema        | [ dpi-command_response.json ](json-schemas/pe/dpi/command_response/dpi-command_response.json)                      |
-| Maintainer    | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                          |
-| Producer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                          |
-| Consumer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                          |
+| Maintainer    | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                              |
+| Producer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                              |
+| Consumer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                              |
 | Service Level | ⛔ PTA internal API. No restrictions apply. May be removed or modified freely by the PTA                           |
 
 This API is reserved for command and control messages for debugging purposes of DPI client.

--- a/asyncapi/json-schemas/pe/dpi/connection_status/dpi-connection-status.md
+++ b/asyncapi/json-schemas/pe/dpi/connection_status/dpi-connection-status.md
@@ -3,9 +3,9 @@
 |---------------|-------------------------------------------------------------------------------------------------------------------|
 | Central Topic | {authorityId}/{operatorId}/{vehicleId}/adt/v4/pe/dpi/connection_status                                            |
 | Schema        | [ dpi-connection-status.json ](json-schemas/pe/dpi/connection_status/dpi-connection-status.json)                  |
-| Maintainer    | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
-| Producer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
-| Consumer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
+| Maintainer    | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
+| Producer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
+| Consumer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
 | Service Level | ⛔ PTA internal API. No restrictions apply. May be removed or modified freely by the PTA                           |
 
 Connection messages sent when the DPI client connects and disconnects from the MQTT broker. It is used to monitor the connection status of the DPI client and detect screens where the browser may be in restart loop.

--- a/asyncapi/json-schemas/pe/dpi/connections/dpi-connections.md
+++ b/asyncapi/json-schemas/pe/dpi/connections/dpi-connections.md
@@ -3,9 +3,9 @@
 |---------------|-------------------------------------------------------------------------------------------------------------------|
 | Central Topic | {operatorId}/{authorityId}/{vehicleId}/adt/v4/pe/dpi/connections                                                  |
 | Schema        | [ dpi-connections.json ](json-schemas/pe/dpi/connections/dpi-connections.json)                                    |
-| Maintainer    | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
-| Producer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
-| Consumer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
+| Maintainer    | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
+| Producer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
+| Consumer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
 | Service Level | ⛔ PTA internal API. No restrictions apply. May be removed or modified freely by the PTA                           |
 
 List of connections for the remaining stops on a journey with expected departures.

--- a/asyncapi/json-schemas/pe/dpi/diagnostics/dpi-diagnostics.md
+++ b/asyncapi/json-schemas/pe/dpi/diagnostics/dpi-diagnostics.md
@@ -3,9 +3,9 @@
 |---------------|-------------------------------------------------------------------------------------------------------------------|
 | Central Topic | {authorityId}/{operatorId}/{vehicleId}/adt/v4/pe/dpi/diagnostics                                                  |
 | Schema        | [ dpi-diagnostics.json ](json-schemas/pe/dpi/diagnostics/dpi-diagnostics.json)                                    |
-| Maintainer    | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
-| Producer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
-| Consumer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
+| Maintainer    | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
+| Producer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
+| Consumer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
 | Service Level | ⛔ PTA internal API. No restrictions apply. May be removed or modified freely by the PTA                           |
 
 Report to PTA BO about a screen.

--- a/asyncapi/json-schemas/pe/dpi/display_status/dpi-display-status.md
+++ b/asyncapi/json-schemas/pe/dpi/display_status/dpi-display-status.md
@@ -3,9 +3,9 @@
 |---------------|-----------------------------------------------------------------------------------------------------------|
 | Central Topic | {authorityId}/{operatorId}/{vehicleId}/adt/v4/pe/dpi/display_status                                       |
 | Schema        | [ dpi-display-status.json ](json-schemas/pe/dpi/display_status/dpi-display-status.json)                   |
-| Maintainer    | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                 |
-| Producer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                 |
-| Consumer      | PTO, [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                            |
+| Maintainer    | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                     |
+| Producer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                     |
+| Consumer      | PTO, [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                |
 | Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version. |
 
 The DPI Display status topic is used to inform the Ruter BO about the current state (Tilstandsmelding) for DPI.

--- a/asyncapi/json-schemas/pe/dpi/eta/dpi-eta.md
+++ b/asyncapi/json-schemas/pe/dpi/eta/dpi-eta.md
@@ -3,9 +3,9 @@
 |---------------|-------------------------------------------------------------------------------------------------------------------|
 | Central Topic | {operatorId}/{authorityId}/{vehicleId}/adt/v4/pe/dpi/eta                                                          |
 | Schema        | [ dpi-eta.json ](json-schemas/pe/dpi/eta/dpi-eta.json)                                                            |
-| Maintainer    | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
-| Producer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
-| Consumer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
+| Maintainer    | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
+| Producer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
+| Consumer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
 | Service Level | ⛔ PTA internal API. No restrictions apply. May be removed or modified freely by the PTA                            |
 
 Estimated arrival at the remaining stops.

--- a/asyncapi/json-schemas/pe/dpi/externaldisplay/dpi-externaldisplay.md
+++ b/asyncapi/json-schemas/pe/dpi/externaldisplay/dpi-externaldisplay.md
@@ -3,8 +3,8 @@
 |---------------|-----------------------------------------------------------------------------------------------------------|
 | Central Topic | {operatorId}/{authorityId}/{vehicleId}/adt/v4/pe/dpi/externaldisplay                                      |
 | Schema        | [ dpi-externaldisplay.json ](json-schemas/pe/dpi/externaldisplay/dpi-externaldisplay.json)                |
-| Maintainer    | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                 |
-| Producer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                 |
+| Maintainer    | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                     |
+| Producer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                     |
 | Consumer      | PTO                                                                                                       |
 | Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version. |
 

--- a/asyncapi/json-schemas/pe/dpi/feature_toggle/dpi-feature-toggle.md
+++ b/asyncapi/json-schemas/pe/dpi/feature_toggle/dpi-feature-toggle.md
@@ -3,9 +3,9 @@
 |---------------|-------------------------------------------------------------------------------------------------------------------|
 | Central Topic | {operatorId}/{authorityId}/{vehicleId}/adt/v4/pe/dpi/feature_toggle                                               |
 | Schema        | [ dpi-feature-toggle.json ](json-schemas/pe/dpi/feature_toggle/dpi-feature-toggle.json)                           |
-| Maintainer    | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
-| Producer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
-| Consumer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
+| Maintainer    | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
+| Producer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
+| Consumer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
 | Service Level | ⛔ PTA internal API. No restrictions apply. May be removed or modified freely by the PTA                           |
 
 Message with all active and inactive features.

--- a/asyncapi/json-schemas/pe/dpi/journey/dpi-journey.md
+++ b/asyncapi/json-schemas/pe/dpi/journey/dpi-journey.md
@@ -3,9 +3,9 @@
 |---------------|-------------------------------------------------------------------------------------------------------------------|
 | Central Topic | {operatorId}/{authorityId}/{vehicleId}/adt/v4/pe/dpi/journey                                                      |
 | Schema        | [ dpi-journey.json ](json-schemas/pe/dpi/journey/dpi-journey.json)                                                |
-| Maintainer    | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
-| Producer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
-| Consumer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
+| Maintainer    | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
+| Producer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
+| Consumer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
 | Service Level | ⛔ PTA internal API. No restrictions apply. May be removed or modified freely by the PTA                           |
 
 Message containing the stops included in the journey, connections to other lines, positions ++.

--- a/asyncapi/json-schemas/pe/dpi/key_stops/dpi-key_stops.md
+++ b/asyncapi/json-schemas/pe/dpi/key_stops/dpi-key_stops.md
@@ -3,9 +3,9 @@
 |---------------|---------------------------------------------------------|
 | Central Topic | {operatorId}/{authorityId}/{vehicleId}/adt/v4/pe/dpi/key_stops|
 | Schema        | [ dpi-key_stops.json ](json-schemas/pe/dpi/key_stops/dpi-key_stops.json)|
-| Maintainer    | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
-| Producer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
-| Consumer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
+| Maintainer    | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
+| Producer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
+| Consumer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
 | Service Level | ⛔ PTA internal API. No restrictions apply. May be removed or modified freely by the PTA                           |
 
 List of X number of most trafficked stops in the rest of the journey. Based on predicted number of passengers leaving

--- a/asyncapi/json-schemas/pe/dpi/logs/dpi-logs.md
+++ b/asyncapi/json-schemas/pe/dpi/logs/dpi-logs.md
@@ -3,9 +3,9 @@
 |---------------|-------------------------------------------------------------------------------------------------------------------|
 | Central Topic | {authorityId}/{operatorId}/{vehicleId}/adt/v4/pe/dpi/logs                                                         |
 | Schema        | [ dpi-logs.json ](json-schemas/pe/dpi/logs/dpi-logs.json)                                                         |
-| Maintainer    | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
-| Producer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
-| Consumer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
+| Maintainer    | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
+| Producer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
+| Consumer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
 | Service Level | ⛔ PTA internal API. No restrictions apply. May be removed or modified freely by the PTA                           |
 
 Logs from the DPI client are published to this topic. The payload includes the log level and message, and may include a stack trace when available.

--- a/asyncapi/json-schemas/pe/dpi/nextstop/dpi-nextstop.md
+++ b/asyncapi/json-schemas/pe/dpi/nextstop/dpi-nextstop.md
@@ -3,9 +3,9 @@
 |---------------|-------------------------------------------------------------------------------------------------------------------|
 | Central Topic | {operatorId}/{authorityId}/{vehicleId}/adt/v4/pe/dpi/nextstop                                                     |
 | Schema        | [ dpi-nextstop.json ](json-schemas/pe/dpi/nextstop/dpi-nextstop.json)                                             |
-| Maintainer    | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
-| Producer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
-| Consumer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
+| Maintainer    | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
+| Producer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
+| Consumer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
 | Service Level | ⛔ PTA internal API. No restrictions apply. May be removed or modified freely by the PTA                           |
 
 Next stop on the buss route after leaving a stop.

--- a/asyncapi/json-schemas/pe/dpi/pa/dpi-pa.md
+++ b/asyncapi/json-schemas/pe/dpi/pa/dpi-pa.md
@@ -3,9 +3,9 @@
 |---------------|-------------------------------------------------------------------------------------------------------------------|
 | Central Topic | {operatorId}/{authorityId}/{vehicleId}/adt/v4/pe/dpi/pa                                                           |
 | Schema        | [ dpi-pa.json ](json-schemas/pe/dpi/pa/dpi-pa.json)                                                               |
-| Maintainer    | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
-| Producer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
-| Consumer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
+| Maintainer    | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
+| Producer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
+| Consumer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
 | Service Level | ⛔ PTA internal API. No restrictions apply. May be removed or modified freely by the PTA                           |
 
 Message to be shown on internal displays. May contain references to videos, html, images, text etc.

--- a/asyncapi/json-schemas/pe/sales/current_stop/sales-current_stop.md
+++ b/asyncapi/json-schemas/pe/sales/current_stop/sales-current_stop.md
@@ -3,7 +3,7 @@
 |---------------|-------------------------------------------------------------------------------------------------------------------|
 | Central Topic | {operatorId}/{authorityId}/{vehicleId}/adt/v4/pe/sales/current_stop                                               |
 | Schema        | [ sales-current_stop.json ](json-schemas/pe/sales/current_stop/sales-current_stop.json)                           |
-| Maintainer    | PTA Backoffice                                                                                                    |
+| Maintainer    | [Betjent salg](https://github.com/orgs/RuterNo/teams/rutersalg)                                                   |
 | Producer      | [Betjent salg](https://github.com/orgs/RuterNo/teams/rutersalg)                                                   |
 | Consumer      | [Betjent salg](https://github.com/orgs/RuterNo/teams/rutersalg)                                                   |
 | Service Level | ⛔ PTA internal API. No restrictions apply. May be removed or modified freely by the PTA                            |

--- a/asyncapi/json-schemas/pe/sales/current_stop/sales-current_stop.meta.json
+++ b/asyncapi/json-schemas/pe/sales/current_stop/sales-current_stop.meta.json
@@ -13,6 +13,6 @@
     "sales"
   ],
   "maintainers": [
-    "pta"
+    "sales"
   ]
 }

--- a/asyncapi/json-schemas/pe/sales/diagnostics/sales-diagnostics.md
+++ b/asyncapi/json-schemas/pe/sales/diagnostics/sales-diagnostics.md
@@ -3,7 +3,7 @@
 |---------------|-------------------------------------------------------------------------------------------------------------------|
 | Central Topic | {authorityId}/{operatorId}/{vehicleId}/adt/v4/pe/sales/diagnostics                                                |
 | Schema        | [ sales-diagnostics.json ](json-schemas/pe/sales/diagnostics/sales-diagnostics.json)                              |
-| Maintainer    | PTA Backoffice                                                                                                    |
+| Maintainer    | [Betjent salg](https://github.com/orgs/RuterNo/teams/rutersalg)                                                   |
 | Producer      | [Betjent salg](https://github.com/orgs/RuterNo/teams/rutersalg)                                                   |
 | Consumer      | [Betjent salg](https://github.com/orgs/RuterNo/teams/rutersalg)                                                   |
 | Service Level | ⛔ PTA internal API. No restrictions apply. May be removed or modified freely by the PTA                            |

--- a/asyncapi/json-schemas/pe/sales/diagnostics/sales-diagnostics.meta.json
+++ b/asyncapi/json-schemas/pe/sales/diagnostics/sales-diagnostics.meta.json
@@ -13,6 +13,6 @@
     "sales"
   ],
   "maintainers": [
-    "pta"
+    "sales"
   ]
 }

--- a/asyncapi/json-schemas/pe/sales/sla/sales-sla.md
+++ b/asyncapi/json-schemas/pe/sales/sla/sales-sla.md
@@ -3,7 +3,7 @@
 |---------------|-----------------------------------------------------------------------------------------------------------|
 | Central Topic | {authorityId}/{operatorId}/{vehicleId}/adt/v4/pe/sales/sla                                                |
 | Schema        | [ sales-sla.json ](json-schemas/pe/sales/sla/sales-sla.json)                                              |
-| Maintainer    | PTA Backoffice                                                                                            |
+| Maintainer    | [Betjent salg](https://github.com/orgs/RuterNo/teams/rutersalg)                                           |
 | Producer      | [Betjent salg](https://github.com/orgs/RuterNo/teams/rutersalg)                                           |
 | Consumer      | [Betjent salg](https://github.com/orgs/RuterNo/teams/rutersalg)                                           |
 | Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version.  |

--- a/asyncapi/json-schemas/pe/sales/sla/sales-sla.meta.json
+++ b/asyncapi/json-schemas/pe/sales/sla/sales-sla.meta.json
@@ -13,6 +13,6 @@
     "sales"
   ],
   "maintainers": [
-    "pta"
+    "sales"
   ]
 }

--- a/asyncapi/json-schemas/pe/vehicle/api/api.md
+++ b/asyncapi/json-schemas/pe/vehicle/api/api.md
@@ -3,9 +3,9 @@
 |---------------|-------------------------------------------------------------------------------------------------------------------|
 | Central Topic | {operatorId}/{authorityId}/{vehicleId}/adt/v4/pe/vehicle/api                                                      |
 | Schema        | [ api.json ](json-schemas/pe/vehicle/api/api.json)                                                                |
-| Maintainer    | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
-| Producer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                         |
-| Consumer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team), [Betjent salg](https://github.com/orgs/RuterNo/teams/rutersalg)  |
+| Maintainer    | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
+| Producer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                             |
+| Consumer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team), [Betjent salg](https://github.com/orgs/RuterNo/teams/rutersalg)      |
 | Service Level | ⛔ PTA internal API. No restrictions apply. May be removed or modified freely by the PTA                           |
 
 Message used by the PTA to distribute information about the vehicle and it's supported APIs as provided by the PTO.

--- a/asyncapi/json-schemas/sensors/accelerometer/accelerometer.md
+++ b/asyncapi/json-schemas/sensors/accelerometer/accelerometer.md
@@ -4,9 +4,9 @@
 |---------------|-----------------------------------------------------------------------------------------------------------|
 | Central Topic | {authorityId}/{operatorId}/{vehicleId}/adt/v4/sensors/accelerometer                                       |
 | Schema        | [ accelerometer.json ](json-schemas/sensors/accelerometer/accelerometer.json)                             |
-| Maintainer    | PTA Backoffice                                                                                            |
+| Maintainer    | [Miljødata](https://github.com/orgs/RuterNo/teams/miljodata))                                             |
 | Producer      | PTO                                                                                                       |
-| Consumer      | PTA Backoffice                                                                                            |
+| Consumer      | PTA                                                                                                       |
 | Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version.  |
 
 Expects a message that provides aggregated acceleration measurements over a 10-second interval. Each payload must

--- a/asyncapi/json-schemas/sensors/accelerometer/accelerometer.meta.json
+++ b/asyncapi/json-schemas/sensors/accelerometer/accelerometer.meta.json
@@ -13,6 +13,6 @@
     "pta"
   ],
   "maintainers": [
-    "pta"
+    "telemetry"
   ]
 }

--- a/asyncapi/json-schemas/sensors/apc/apc.md
+++ b/asyncapi/json-schemas/sensors/apc/apc.md
@@ -3,7 +3,7 @@
 |---------------|-----------------------------------------------------------------------------------------------------------|
 | Central Topic | {authorityId}/{operatorId}/{vehicleId}/adt/v4/sensors/apc/{sensorId}                                      |
 | Schema        | [ apc.json ](json-schemas/sensors/apc/apc.json)                                                           |
-| Maintainer    | PTA Backoffice                                                                                            |
+| Maintainer    | [Passasjertelling](https://github.com/orgs/RuterNo/teams/passasjertelling)                                |
 | Producer      | PTO                                                                                                       |
-| Consumer      | PTA Backoffice                                                                                            |
+| Consumer      | PTA                                                                                                       |
 | Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version.  |

--- a/asyncapi/json-schemas/sensors/apc/apc.meta.json
+++ b/asyncapi/json-schemas/sensors/apc/apc.meta.json
@@ -16,6 +16,6 @@
     "pta"
   ],
   "maintainers": [
-    "pta"
+    "apc"
   ]
 }

--- a/asyncapi/json-schemas/sensors/charging/charging.md
+++ b/asyncapi/json-schemas/sensors/charging/charging.md
@@ -4,9 +4,9 @@
 |:--------------|:----------------------------------------------------------------------------------------------------------|
 | Central Topic | {authorityId}/{operatorId}/{vehicleId}/adt/v4/sensors/charging                                            |
 | Schema        | [ charging.json ](json-schemas/sensors/charging/charging.json)                                            |
-| Maintainer    | PTA Backoffice                                                                                            |
+| Maintainer    | [Miljødata](https://github.com/orgs/RuterNo/teams/miljodata))                                             |
 | Producer      | PTO                                                                                                       |
-| Consumer      | PTA Backoffice                                                                                            |
+| Consumer      | PTA                                                                                                       |
 | Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version. |
 
 Describes the charging status and details of an electric vehicle. The message includes information about whether the

--- a/asyncapi/json-schemas/sensors/charging/charging.meta.json
+++ b/asyncapi/json-schemas/sensors/charging/charging.meta.json
@@ -14,6 +14,6 @@
     "pta"
   ],
   "maintainers": [
-    "pta"
+    "telemetry"
   ]
 }

--- a/asyncapi/json-schemas/sensors/door/door.md
+++ b/asyncapi/json-schemas/sensors/door/door.md
@@ -3,9 +3,9 @@
 |---------------|-----------------------------------------------------------------------------------------------------------|
 | Central Topic | {authorityId}/{operatorId}/{vehicleId}/adt/v4/sensors/door                                                |
 | Schema        | [ door.json ](json-schemas/sensors/door/door.json)                                                        |
-| Maintainer    | PTA Backoffice                                                                                            |
+| Maintainer    | [Passasjertelling](https://github.com/orgs/RuterNo/teams/passasjertelling)                                |
 | Producer      | PTO                                                                                                       |
-| Consumer      | PTA Backoffice                                                                                            |
+| Consumer      | PTA                                                                                                       |
 | Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version.  |
 
 Frequency: on change

--- a/asyncapi/json-schemas/sensors/door/door.meta.json
+++ b/asyncapi/json-schemas/sensors/door/door.meta.json
@@ -13,6 +13,6 @@
     "pta"
   ],
   "maintainers": [
-    "pta"
+    "apc"
   ]
 }

--- a/asyncapi/json-schemas/sensors/energy-consumption/energy-consumption.md
+++ b/asyncapi/json-schemas/sensors/energy-consumption/energy-consumption.md
@@ -4,9 +4,9 @@
 |---------------|-----------------------------------------------------------------------------------------------------------|
 | Central Topic | {authorityId}/{operatorId}/{vehicleId}/adt/v4/sensors/energy_consumption                                  |
 | Schema        | [ energy-consumption.json ](json-schemas/sensors/energy-consumption/energy-consumption.json)              |
-| Maintainer    | PTA Backoffice                                                                                            |
+| Maintainer    | [Miljødata](https://github.com/orgs/RuterNo/teams/miljodata))                                             |
 | Producer      | PTO                                                                                                       |
-| Consumer      | PTA Backoffice                                                                                            |
+| Consumer      | PTA                                                                                                       |
 | Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version. |
 
 Energy consumption in kilowatt-hours (kWh), including all onboard systems such as HVAC. The value should always

--- a/asyncapi/json-schemas/sensors/energy-consumption/energy-consumption.meta.json
+++ b/asyncapi/json-schemas/sensors/energy-consumption/energy-consumption.meta.json
@@ -13,6 +13,6 @@
     "pta"
   ],
   "maintainers": [
-    "pta"
+    "apc"
   ]
 }

--- a/asyncapi/json-schemas/sensors/energy-consumption/energy-consumption.meta.json
+++ b/asyncapi/json-schemas/sensors/energy-consumption/energy-consumption.meta.json
@@ -13,6 +13,6 @@
     "pta"
   ],
   "maintainers": [
-    "apc"
+    "telemetry"
   ]
 }

--- a/asyncapi/json-schemas/sensors/location/location.md
+++ b/asyncapi/json-schemas/sensors/location/location.md
@@ -4,9 +4,9 @@
 |---------------|-----------------------------------------------------------------------------------------------------------|
 | Central Topic | {authorityId}/{operatorId}/{vehicleId}/adt/v4/sensors/location                                            |
 | Schema        | [ location.json ](json-schemas/sensors/location/location.json)                                            |
-| Maintainer    | PTA Backoffice                                                                                            |
+| Maintainer    | [Progress](https://github.com/orgs/RuterNo/teams/progress)                                                |
 | Producer      | PTO                                                                                                       |
-| Consumer      | PTA Backoffice                                                                                            |
+| Consumer      | PTA                                                                                                       |
 | Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version. |
 
 Describes the GNSS navigation receiver feedback in metric format.

--- a/asyncapi/json-schemas/sensors/location/location.meta.json
+++ b/asyncapi/json-schemas/sensors/location/location.meta.json
@@ -13,6 +13,6 @@
     "pta"
   ],
   "maintainers": [
-    "pta"
+    "progress"
   ]
 }

--- a/asyncapi/json-schemas/sensors/odometer/odometer.md
+++ b/asyncapi/json-schemas/sensors/odometer/odometer.md
@@ -3,9 +3,9 @@
 |---------------|-----------------------------------------------------------------------------------------------------------|
 | Central Topic | {authorityId}/{operatorId}/{vehicleId}/adt/v4/sensors/odometer                                            |
 | Schema        | [ odometer.json ](json-schemas/sensors/odometer/odometer.json)                                            |
-| Maintainer    | PTA Backoffice                                                                                            |
+| Maintainer    | [Progress](https://github.com/orgs/RuterNo/teams/progress)                                                |
 | Producer      | PTO                                                                                                       |
-| Consumer      | PTA Backoffice                                                                                            |
+| Consumer      | PTA                                                                                                       |
 | Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version.  |
 
 Describes an odometer value in meters based on total vehicle distance or similar. Absolute value of less importance but

--- a/asyncapi/json-schemas/sensors/odometer/odometer.meta.json
+++ b/asyncapi/json-schemas/sensors/odometer/odometer.meta.json
@@ -13,6 +13,6 @@
     "pta"
   ],
   "maintainers": [
-    "pta"
+    "progress"
   ]
 }

--- a/asyncapi/json-schemas/sensors/state-of-charge/state-of-charge.md
+++ b/asyncapi/json-schemas/sensors/state-of-charge/state-of-charge.md
@@ -4,9 +4,9 @@
 |---------------|-----------------------------------------------------------------------------------------------------------|
 | Central Topic | {authorityId}/{operatorId}/{vehicleId}/adt/v4/sensors/state_of_charge                                     |
 | Schema        | [ state-of-charge.json ](json-schemas/sensors/state-of-charge/state-of-charge.json)                       |
-| Maintainer    | PTA Backoffice                                                                                            |
+| Maintainer    | [Miljødata](https://github.com/orgs/RuterNo/teams/miljodata))                                             |
 | Producer      | PTO                                                                                                       |
-| Consumer      | PTA Backoffice                                                                                            |
+| Consumer      | PTA                                                                                                       |
 | Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version.  |
 
 Describes the current charge level of the vehicle's battery.

--- a/asyncapi/json-schemas/sensors/state-of-charge/state-of-charge.meta.json
+++ b/asyncapi/json-schemas/sensors/state-of-charge/state-of-charge.meta.json
@@ -13,6 +13,6 @@
     "pta"
   ],
   "maintainers": [
-    "pta"
+    "telemetry"
   ]
 }

--- a/asyncapi/json-schemas/sensors/stop-button/stop-button.md
+++ b/asyncapi/json-schemas/sensors/stop-button/stop-button.md
@@ -3,9 +3,9 @@
 |---------------|-----------------------------------------------------------------------------------------------------------|
 | Central Topic | {authorityId}/{operatorId}/{vehicleId}/adt/v4/sensors/stop_button                                         |
 | Schema        | [ stop-button.json ](json-schemas/sensors/stop-button/stop-button.json)                                   |
-| Maintainer    | PTA Backoffice                                                                                            |
+| Maintainer    | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                     |
 | Producer      | PTO                                                                                                       |
-| Consumer      | [PTA DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                 |
+| Consumer      | [DPI](https://github.com/orgs/RuterNo/teams/dpi-team)                                                     |
 | Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version.  |
 
 This message should be produced whenever the stop signal is turned on or off. Depending on whether the regular stop button

--- a/asyncapi/json-schemas/sensors/stop-button/stop-button.meta.json
+++ b/asyncapi/json-schemas/sensors/stop-button/stop-button.meta.json
@@ -13,6 +13,6 @@
     "dpi"
   ],
   "maintainers": [
-    "pta"
+    "dpi"
   ]
 }

--- a/asyncapi/json-schemas/sensors/temperature-indoor/temperature-indoor.md
+++ b/asyncapi/json-schemas/sensors/temperature-indoor/temperature-indoor.md
@@ -4,9 +4,9 @@
 |---------------|-----------------------------------------------------------------------------------------------------------|
 | Central Topic | {authorityId}/{operatorId}/{vehicleId}/adt/v4/sensors/temperature_indoor                                  |
 | Schema        | [ temperature-indoor.json ](json-schemas/sensors/temperature-indoor/temperature-indoor.json)              |
-| Maintainer    | PTA Backoffice                                                                                            |
+| Maintainer    | [Miljødata](https://github.com/orgs/RuterNo/teams/miljodata))                                             |
 | Producer      | PTO                                                                                                       |
-| Consumer      | PTA Backoffice                                                                                            |
+| Consumer      | PTA                                                                                                       |
 | Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version.  |
 
 Describes the measured air temperature inside a vehicle. Each message corresponds to one

--- a/asyncapi/json-schemas/sensors/temperature-indoor/temperature-indoor.meta.json
+++ b/asyncapi/json-schemas/sensors/temperature-indoor/temperature-indoor.meta.json
@@ -13,6 +13,6 @@
     "pta"
   ],
   "maintainers": [
-    "pta"
+    "telemetry"
   ]
 }

--- a/asyncapi/json-schemas/sensors/temperature-outdoor/temperature-outdoor.md
+++ b/asyncapi/json-schemas/sensors/temperature-outdoor/temperature-outdoor.md
@@ -4,9 +4,9 @@
 |---------------|-----------------------------------------------------------------------------------------------------------|
 | Central Topic | {authorityId}/{operatorId}/{vehicleId}/adt/v4/sensors/temperature_outdoor                                 |
 | Schema        | [ temperature-outdoor.json ](json-schemas/sensors/temperature-outdoor/temperature-outdoor.json)           |
-| Maintainer    | PTA Backoffice                                                                                            |
+| Maintainer    | [Miljødata](https://github.com/orgs/RuterNo/teams/miljodata))                                             |
 | Producer      | PTO                                                                                                       |
-| Consumer      | PTA Backoffice                                                                                            |
+| Consumer      | PTA                                                                                                       |
 | Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version.  |
 
 Measurement of the external temperature around the vehicle.

--- a/asyncapi/json-schemas/sensors/temperature-outdoor/temperature-outdoor.meta.json
+++ b/asyncapi/json-schemas/sensors/temperature-outdoor/temperature-outdoor.meta.json
@@ -13,6 +13,6 @@
     "pta"
   ],
   "maintainers": [
-    "pta"
+    "telemetry"
   ]
 }

--- a/asyncapi/json-schemas/sensors/temperature-water/temperature-water.md
+++ b/asyncapi/json-schemas/sensors/temperature-water/temperature-water.md
@@ -4,9 +4,9 @@
 |---------------|-----------------------------------------------------------------------------------------------------------|
 | Central Topic | {authorityId}/{operatorId}/{vehicleId}/adt/v4/sensors/temperature_water                                   |
 | Schema        | [ temperature-water.json ](json-schemas/sensors/temperature-water/temperature-water.json)                 |
-| Maintainer    | PTA Backoffice                                                                                            |
+| Maintainer    | [Miljødata](https://github.com/orgs/RuterNo/teams/miljodata))                                             |
 | Producer      | PTO                                                                                                       |
-| Consumer      | PTA Backoffice                                                                                            |
+| Consumer      | PTA                                                                                                       |
 | Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version.  |
 
 Describes the water temperature in Celsius, measured 1 meter below the water surface. The value should be a float with a

--- a/asyncapi/json-schemas/sensors/temperature-water/temperature-water.meta.json
+++ b/asyncapi/json-schemas/sensors/temperature-water/temperature-water.meta.json
@@ -13,6 +13,6 @@
     "pta"
   ],
   "maintainers": [
-    "pta"
+    "telemetry"
   ]
 }

--- a/asyncapi/json-schemas/sensors/windscreen-wiper/windscreen-wiper.md
+++ b/asyncapi/json-schemas/sensors/windscreen-wiper/windscreen-wiper.md
@@ -4,9 +4,9 @@
 |---------------|-----------------------------------------------------------------------------------------------------------|
 | Central Topic | {authorityId}/{operatorId}/{vehicleId}/adt/v4/sensors/windscreen_wiper                                    |
 | Schema        | [ windscreen-wiper.json ](json-schemas/sensors/windscreen-wiper/windscreen-wiper.json)                    |
-| Maintainer    | PTA Backoffice                                                                                            |
+| Maintainer    | [Miljødata](https://github.com/orgs/RuterNo/teams/miljodata))                                             |
 | Producer      | PTO                                                                                                       |
-| Consumer      | PTA Backoffice                                                                                            |
+| Consumer      | PTA                                                                                                       |
 | Service Level | ✅ External API. Restrictions apply. Only backward compatible changes may happen within the major version.  |
 
 Describes the activity of the windscreen wipers.

--- a/asyncapi/json-schemas/sensors/windscreen-wiper/windscreen-wiper.meta.json
+++ b/asyncapi/json-schemas/sensors/windscreen-wiper/windscreen-wiper.meta.json
@@ -13,6 +13,6 @@
     "pta"
   ],
   "maintainers": [
-    "pta"
+    "telemetry"
   ]
 }

--- a/scripts/asyncapi_generate.py
+++ b/scripts/asyncapi_generate.py
@@ -29,8 +29,8 @@ VEHICLE = "{vehicleId}"
 BACKOFFICE = "backoffice"
 
 CWD = Path.cwd()
-PROJECT_ROOT = CWD.parent if CWD.name == "scripts" else CWD
-SCHEMA_ROOT = PROJECT_ROOT / "asyncapi" / "json-schemas"
+PROJECT_ROOT = (CWD.parent if CWD.name == "scripts" else CWD) / "asyncapi"
+SCHEMA_ROOT = PROJECT_ROOT / "json-schemas"
 
 CREATE_META_IF_MISSING = False
 META_FILE_TEMPLATE = {'mode': 'TODO', 'mqtt': {'qos': 'TODO', 'retain': 'TODO'}, "topic": "TODO"}
@@ -371,7 +371,7 @@ def main():
     schemas = resolve_schemas()
     update_schema_content(schemas)
     validate_examples(schemas)
-    asyncapi_path = PROJECT_ROOT / "asyncapi" / "asyncapi.yml"
+    asyncapi_path = PROJECT_ROOT / "asyncapi.yml"
     async_api = read_yaml(asyncapi_path)
 
     for name, paths in schemas.items():

--- a/scripts/asyncapi_generate.py
+++ b/scripts/asyncapi_generate.py
@@ -42,7 +42,7 @@ SERVICE_LEVELS = {
 
 TEAMS = {
     'pto': 'PTO',
-    'pta': 'PTA Backoffice',
+    'pta': 'PTA',
     'dpi': '[DPI](https://github.com/orgs/RuterNo/teams/dpi-team)',
     'apc': '[Passasjertelling](https://github.com/orgs/RuterNo/teams/passasjertelling)',
     'assignment': '[Assignment](https://github.com/orgs/RuterNo/teams/assignment)',


### PR DESCRIPTION
- Fixes a bug in the script that would add `asyncapi` twice in the path
- Adds a team as maintainer for each topic
- Removed `PTA` prefix on team name
- Removed `Backoffice` suffix for PTA since it can also be a consumer on the vehicle

This set a team as owner for each existing topic with the exception of `operatorId}/{authorityId}/{vehicleId}/adt/v4/di/operational_message_to_driver` which has no given maintainer.