### PR TITLE
update operation id for generator_fuel_consumption

### DIFF
--- a/asyncapi/asyncapi.yml
+++ b/asyncapi/asyncapi.yml
@@ -361,7 +361,7 @@ channels:
           mqtt:
             qos: 0
             retain: false
-  sensors/generator-fuel-consumption:
+  sensors/generator_fuel_consumption:
     description:
       $ref: json-schemas/sensors/generator-fuel-consumption/generator-fuel-consumption.md
     publish:


### PR DESCRIPTION
Fått en liten tilbakemelding på de nye meldingene som ble opprettet.
Det er så enkelt at det er i teksten i API brukt en blanding av bindestrek -  og underscore _.
" PUB sensors/generator-fuel-consumption"
"ruter/{operatorId}/{vehicleId}/adt/v3/sensors/generator_fuel_consumption"